### PR TITLE
chore: github action build only on push or dispatch workflow manually

### DIFF
--- a/.github/workflows/build-apitable.yaml
+++ b/.github/workflows/build-apitable.yaml
@@ -8,6 +8,7 @@ on:
 jobs:
   buildpush:
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
     env:
       APITABLE_DOCKER_HUB_TOKEN: ${{ secrets.APITABLE_DOCKER_HUB_TOKEN }}
     steps:


### PR DESCRIPTION

github action build only on push or dispatch workflow manually