### PR TITLE
fix: codeql (javascript) out of memory

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -41,6 +41,28 @@ jobs:
       uses: github/codeql-action/analyze@v2
       with:
         category: "/language:java"
+  analyze-js-core:
+    name: Analyze (javascript-core)
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+    # Initializes the CodeQL tools for scanning.
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v2
+      with:
+        languages: javascript
+    - run: |
+        echo "Run, Build JavaScript Core Application"
+        make _build-core
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v2
+      with:
+        category: "/language:javascript"
 
   # analyze:
   #   name: Analyze

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -84,27 +84,27 @@ jobs:
       with:
         category: "/language:javascript"
 
-  analyze-js-web:
-    name: Analyze (javascript-web)
-    runs-on: ubuntu-latest
-    permissions:
-      actions: read
-      contents: read
-      security-events: write
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@v3
-    # Initializes the CodeQL tools for scanning.
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
-      with:
-        languages: javascript
-    - run: |
-        make _build-web
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
-      with:
-        category: "/language:javascript"
+  # analyze-js-web:
+  #   name: Analyze (javascript-web)
+  #   runs-on: ubuntu-latest
+  #   permissions:
+  #     actions: read
+  #     contents: read
+  #     security-events: write
+  #   steps:
+  #   - name: Checkout repository
+  #     uses: actions/checkout@v3
+  #   # Initializes the CodeQL tools for scanning.
+  #   - name: Initialize CodeQL
+  #     uses: github/codeql-action/init@v2
+  #     with:
+  #       languages: javascript
+  #   - run: |
+  #       make _build-web
+  #   - name: Perform CodeQL Analysis
+  #     uses: github/codeql-action/analyze@v2
+  #     with:
+  #       category: "/language:javascript"
 
   # analyze:
   #   name: Analyze

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -17,60 +17,81 @@ on:
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ "develop" ]
-  schedule:
-    - cron: '26 16 * * 5'
 
 jobs:
-  analyze:
-    name: Analyze
+  analyze-java:
+    name: Analyze (Java)
     runs-on: ubuntu-latest
     permissions:
       actions: read
       contents: read
       security-events: write
-
-    strategy:
-      fail-fast: false
-      matrix:
-        language: [ 'java', 'javascript' ]
-        # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
-        # Use only 'java' to analyze code written in Java, Kotlin or both
-        # Use only 'javascript' to analyze code written in JavaScript, TypeScript or both
-        # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
-
     steps:
     - name: Checkout repository
       uses: actions/checkout@v3
-
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v2
       with:
-        languages: ${{ matrix.language }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
-
-        # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
-        # queries: security-extended,security-and-quality
-
-
-    # Autobuild attempts to build any compiled languages  (C/C++, C#, Go, or Java).
-    # If this step fails, then you should remove it and run the build manually (see below)
-    # - name: Autobuild
-    #   uses: github/codeql-action/autobuild@v2
-
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
-
-    #   If the Autobuild fails above, remove it and uncomment the following three lines.
-    #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
-
+        languages: java
     - run: |
-        echo "Run, Build Application"
-        make build
-
+        echo "Run, Build Java Application"
+        make _build-java
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2
       with:
-        category: "/language:${{matrix.language}}"
+        category: "/language:java"
+
+  # analyze:
+  #   name: Analyze
+  #   runs-on: ubuntu-latest
+  #   permissions:
+  #     actions: read
+  #     contents: read
+  #     security-events: write
+
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       language: [ 'java', 'javascript' ]
+  #       # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
+  #       # Use only 'java' to analyze code written in Java, Kotlin or both
+  #       # Use only 'javascript' to analyze code written in JavaScript, TypeScript or both
+  #       # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
+
+  #   steps:
+  #   - name: Checkout repository
+  #     uses: actions/checkout@v3
+
+  #   # Initializes the CodeQL tools for scanning.
+  #   - name: Initialize CodeQL
+  #     uses: github/codeql-action/init@v2
+  #     with:
+  #       languages: ${{ matrix.language }}
+  #       # If you wish to specify custom queries, you can do so here or in a config file.
+  #       # By default, queries listed here will override any specified in a config file.
+  #       # Prefix the list here with "+" to use these queries and those in the config file.
+
+  #       # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
+  #       # queries: security-extended,security-and-quality
+
+
+  #   # Autobuild attempts to build any compiled languages  (C/C++, C#, Go, or Java).
+  #   # If this step fails, then you should remove it and run the build manually (see below)
+  #   # - name: Autobuild
+  #   #   uses: github/codeql-action/autobuild@v2
+
+  #   # ℹ️ Command-line programs to run using the OS shell.
+  #   # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
+
+  #   #   If the Autobuild fails above, remove it and uncomment the following three lines.
+  #   #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
+
+  #   - run: |
+  #       echo "Run, Build Application"
+  #       make build
+
+  #   - name: Perform CodeQL Analysis
+  #     uses: github/codeql-action/analyze@v2
+  #     with:
+  #       category: "/language:${{matrix.language}}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -35,7 +35,6 @@ jobs:
       with:
         languages: java
     - run: |
-        echo "Run, Build Java Application"
         make _build-java
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2
@@ -57,8 +56,51 @@ jobs:
       with:
         languages: javascript
     - run: |
-        echo "Run, Build JavaScript Core Application"
         make _build-core
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v2
+      with:
+        category: "/language:javascript"
+
+  analyze-js-room:
+    name: Analyze (javascript-room)
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+    # Initializes the CodeQL tools for scanning.
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v2
+      with:
+        languages: javascript
+    - run: |
+        make _build-room
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v2
+      with:
+        category: "/language:javascript"
+
+  analyze-js-web:
+    name: Analyze (javascript-web)
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+    # Initializes the CodeQL tools for scanning.
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v2
+      with:
+        languages: javascript
+    - run: |
+        make _build-web
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2
       with:


### PR DESCRIPTION
CodeQL Github Action failed

The TypeScript parser wrapper crashed, possibly from running out of memory.

Separate them into multi step with different Github Action VM

<img width="1413" alt="image" src="https://user-images.githubusercontent.com/520852/210614415-8f597427-ae95-4294-a81e-5088364b1def.png">
