### PR TITLE
Fix bug in percentage field reset(issues#121)

### DIFF
--- a/packages/datasheet/src/pc/components/editors/number_editor/number_editor.tsx
+++ b/packages/datasheet/src/pc/components/editors/number_editor/number_editor.tsx
@@ -139,7 +139,7 @@ const NumberEditorBase: React.ForwardRefRenderFunction<IEditor, INumberEditorPro
       tempVal = str2NumericStr(tempVal);
       tempVal = tempVal == null ? '' : tempVal;
       if (fieldType === FieldType.Percent) {
-        tempVal = tempVal == null ? '' : String(divide(Number(tempVal), 100));
+        tempVal = (tempVal == null || tempVal == '') ? '' : String(divide(Number(tempVal), 100));
       }
       commandFn && commandFn(tempVal);
       onChange && onChange(tempVal);


### PR DESCRIPTION
Describe the bug
After i filled in a default value of percent field, i couldn't get it back to "empty" state, it always showed a "0" in the input box

To Reproduce
Steps to reproduce the behavior:

Create a field and type is Percent
filled a "5" into the input box of Default value in the field setting modal, and then click the button "OK"
double-click the field name for reopenning the field setting modal, empty the input box of Default value, and then click the button "OK"
double-click the field name again, you will see "0" in the input box of Default value
Expected behavior
Leave it empty when I remove all content from the input box.

Desktop (please complete the following information):

OS: Windows 10
Browser Chrome
Version 108.0.5359.125