### PR TITLE
fix: add pre-action releaseLocks before init-db run

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -225,6 +225,24 @@ services:
       - apitable
 
   # init data
+  pre-init-db:
+    image: ${IMAGE_REGISTRY}/${IMAGE_INIT_DB}
+    pull_policy: ${IMAGE_PULL_POLICY:-if_not_present}
+    environment:
+      - TZ=${TIMEZONE}
+      - DB_HOST=${MYSQL_HOST}
+      - DB_PORT=${MYSQL_PORT}
+      - DB_NAME=${MYSQL_DATABASE}
+      - DB_USERNAME=${MYSQL_USERNAME}
+      - DB_PASSWORD=${MYSQL_PASSWORD}
+      - DATABASE_TABLE_PREFIX=${DATABASE_TABLE_PREFIX}
+      - ACTION=releaseLocks
+    networks:
+      - apitable
+    depends_on:
+      mysql:
+        condition: service_healthy
+  
   init-db:
     image: ${IMAGE_REGISTRY}/${IMAGE_INIT_DB}
     pull_policy: ${IMAGE_PULL_POLICY:-if_not_present}
@@ -240,8 +258,8 @@ services:
     networks:
       - apitable
     depends_on:
-      mysql:
-        condition: service_healthy
+      pre-init-db:
+        condition: service_completed_successfully
 
   # init-appdata
   init-appdata:


### PR DESCRIPTION
# Why? 
sometimes init-db run fail because db changelog lock of liquibase


# What?
cause init-db run waiting timeout


# How?
add pre-action `releaseLocks` in init-db avoid stuck
