### PR TITLE
fix: Percent Field default value cannot be reset to empty #121

### DIFF
--- a/packages/datasheet/src/pc/components/editors/number_editor/number_editor.tsx
+++ b/packages/datasheet/src/pc/components/editors/number_editor/number_editor.tsx
@@ -139,7 +139,7 @@ const NumberEditorBase: React.ForwardRefRenderFunction<IEditor, INumberEditorPro
       tempVal = str2NumericStr(tempVal);
       tempVal = tempVal == null ? '' : tempVal;
       if (fieldType === FieldType.Percent) {
-        tempVal = tempVal == null ? '' : String(divide(Number(tempVal), 100));
+        tempVal = !tempVal ? '' : String(divide(Number(tempVal), 100));
       }
       commandFn && commandFn(tempVal);
       onChange && onChange(tempVal);


### PR DESCRIPTION
Describe the bug
After i filled in a default value of percent field, i couldn't get it back to "empty" state, it always showed a "0" in the input box

To Reproduce
Steps to reproduce the behavior:

    Create a field and type is Percent
    filled a "5" into the input box of Default value in the field setting modal, and then click the button "OK"
    double-click the field name for reopenning the field setting modal, empty the input box of Default value, and then click the button "OK"
    double-click the field name again, you will see "0" in the input box of Default value

Expected behavior
Leave it empty when I remove all content from the input box.

<!-- If you have an Issue that related to this Pull Request, you can copy this Issue's description -->

# Why? 
This PR fixes issue #121 .


# What?
<!-- 
> Can you describe this feature in detail?
> Who can benefit from it? 
-->
This bug happens because they're trying to convert empty string to number (specifically it's 0)  when input value changes.


# How?
Change condition and avoid converting empty string to number.
