### PR TITLE
fixBug#121

### DIFF
--- a/packages/datasheet/src/pc/components/editors/number_editor/number_editor.tsx
+++ b/packages/datasheet/src/pc/components/editors/number_editor/number_editor.tsx
@@ -75,7 +75,7 @@ const NumberEditorBase: React.ForwardRefRenderFunction<IEditor, INumberEditorPro
     blur: () => { blur(); },
     onEndEdit: (cancel: boolean) => { onEndEdit(cancel); },
     onStartEdit: (value?: number | null) => { onStartEdit(value); },
-    setValue: (value?: number | null) => { 
+    setValue: (value?: number | null) => {
       setEditorValue( isNumber(value) ? value : null, true);
     },
     saveValue: () => { saveValue(); },
@@ -139,7 +139,8 @@ const NumberEditorBase: React.ForwardRefRenderFunction<IEditor, INumberEditorPro
       tempVal = str2NumericStr(tempVal);
       tempVal = tempVal == null ? '' : tempVal;
       if (fieldType === FieldType.Percent) {
-        tempVal = tempVal == null ? '' : String(divide(Number(tempVal), 100));
+        // After the user edits, it should be judged that the value is empty
+        tempVal = (tempVal == null || tempVal.trim().length === 0) ? '' : String(divide(Number(tempVal), 100));
       }
       commandFn && commandFn(tempVal);
       onChange && onChange(tempVal);
@@ -148,7 +149,7 @@ const NumberEditorBase: React.ForwardRefRenderFunction<IEditor, INumberEditorPro
 
   const onKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
     const printable = printableKey(event.nativeEvent);
-    // Currently checking, safari, Chrome in Windows, etc. 
+    // Currently checking, safari, Chrome in Windows, etc.
     // when calling the system's Chinese input method (e.g., mac's Chinese and Microsoft's own Chinese)
     // If the KeyCode is listened to via the KeyUp event, the correct value is returned. However, there are two problems with KeyUp.
     // 1. Frequent triggers can be missed


### PR DESCRIPTION
> issues: https://github.com/apitable/apitable/issues/121
> "After i filled in a default value of percent field, i couldn't get it back to "empty" state, it always showed a "0" in the input box"

Why?
fixBug for issues: https://github.com/apitable/apitable/issues/121 .

What?
After the user edits and deletes the value, the value becomes an empty string, but the logical value judges that the value is null

How?
After the user edits, it should be judged that the value is empty string.