### PR TITLE
fix: percent field default value cannot be reset to empty when remove all content from the input box (#121)

### DIFF
--- a/packages/datasheet/src/pc/components/editors/number_editor/number_editor.tsx
+++ b/packages/datasheet/src/pc/components/editors/number_editor/number_editor.tsx
@@ -139,7 +139,7 @@ const NumberEditorBase: React.ForwardRefRenderFunction<IEditor, INumberEditorPro
       tempVal = str2NumericStr(tempVal);
       tempVal = tempVal == null ? '' : tempVal;
       if (fieldType === FieldType.Percent) {
-        tempVal = tempVal == null ? '' : String(divide(Number(tempVal), 100));
+        tempVal = (tempVal == null || tempVal === '') ? '' : String(divide(Number(tempVal), 100));
       }
       commandFn && commandFn(tempVal);
       onChange && onChange(tempVal);


### PR DESCRIPTION
Submit a pull request for this project.

Describe the bug
After i filled in a default value of percent field, i couldn't get it back to "empty" state, it always showed a "0" in the input box

To Reproduce
Steps to reproduce the behavior:
1. Create a field and type is Percent
2. filled a "5" into the input box of Default value in the field setting modal, and then click the button "OK"
3. double-click the field name for reopenning the field setting modal, empty the input box of Default value, and then click the button "OK"
4. double-click the field name again, you will see "0" in the input box of Default value

Expected behavior
Leave it empty when I remove all content from the input box.

# Why? 
This PR fixed issue https://github.com/apitable/apitable/issues/121 .


# What?
This bug happens because function Number trying to convert empty string to number 0 when input value is empty.


# How?
Add conditional judgment to filter out empty string to prevent them from being converted into number.
