### PR TITLE
fix: percent field default cant set to empty in issue #121

### DIFF
--- a/packages/datasheet/src/pc/components/editors/number_editor/number_editor.tsx
+++ b/packages/datasheet/src/pc/components/editors/number_editor/number_editor.tsx
@@ -137,9 +137,10 @@ const NumberEditorBase: React.ForwardRefRenderFunction<IEditor, INumberEditorPro
 
       setValue(tempVal);
       tempVal = str2NumericStr(tempVal);
-      tempVal = tempVal == null ? '' : tempVal;
       if (fieldType === FieldType.Percent) {
         tempVal = tempVal == null ? '' : String(divide(Number(tempVal), 100));
+      } else {
+        tempVal = tempVal == null ? '' : tempVal;
       }
       commandFn && commandFn(tempVal);
       onChange && onChange(tempVal);


### PR DESCRIPTION
Submit a pull request for this project.

# Why? 
- fix issues #121

# What?
In the case, when filed type equals FieldType.Percent, the tempVal will be operated twice. Under correct situation, they should execute in different branch

# How?
Add "else" to avoid duplicate operating
