### PR TITLE
fix: can't reset to empty when the default value of the percent field…

### DIFF
--- a/packages/datasheet/src/pc/components/editors/number_editor/number_editor.tsx
+++ b/packages/datasheet/src/pc/components/editors/number_editor/number_editor.tsx
@@ -139,7 +139,7 @@ const NumberEditorBase: React.ForwardRefRenderFunction<IEditor, INumberEditorPro
       tempVal = str2NumericStr(tempVal);
       tempVal = tempVal == null ? '' : tempVal;
       if (fieldType === FieldType.Percent) {
-        tempVal = tempVal == null ? '' : String(divide(Number(tempVal), 100));
+        tempVal = (tempVal == null || tempVal == '') ? '' : String(divide(Number(tempVal), 100));
       }
       commandFn && commandFn(tempVal);
       onChange && onChange(tempVal);


### PR DESCRIPTION
fix reset input can't reset to empty when the field type is percent(#121)



Submit a pull request for this project.

<!-- If you have an Issue that related to this Pull Request, you can copy this Issue's description -->

# Why? 
issues link:https://github.com/apitable/apitable/issues/121
user can't reset percent type field default value


# What?
<!-- 
> Can you describe this feature in detail?
> Who can benefit from it? 
-->
user can reset percent type field default value


# How?
i add judge at number_editor.tsx:142
before:
tempVal = tempVal == null ? '' : String(divide(Number(tempVal), 100));
after:
tempVal = (tempVal == null || tempVal == '') ? '' : String(divide(Number(tempVal), 100));
