### PR TITLE
fix: percent is still 0 after reset empty the default value

### DIFF
--- a/packages/datasheet/src/pc/components/editors/number_editor/number_editor.tsx
+++ b/packages/datasheet/src/pc/components/editors/number_editor/number_editor.tsx
@@ -139,7 +139,7 @@ const NumberEditorBase: React.ForwardRefRenderFunction<IEditor, INumberEditorPro
       tempVal = str2NumericStr(tempVal);
       tempVal = tempVal == null ? '' : tempVal;
       if (fieldType === FieldType.Percent) {
-        tempVal = tempVal == null ? '' : String(divide(Number(tempVal), 100));
+        tempVal = (tempVal == null || tempVal === '') ? '' : String(divide(Number(tempVal), 100));
       }
       commandFn && commandFn(tempVal);
       onChange && onChange(tempVal);


### PR DESCRIPTION

Submit a pull request for this project.

<!-- If you have an Issue that related to this Pull Request, you can copy this Issue's description -->

# Why? 
<!-- 
> Related to which issue?
> Why we need this pull request?
> What is the user story for this pull request? 
-->
This PR is fix issues: [fix: it couldn't be reset to empty when the default value of the percent field is filled in #121](https://github.com/apitable/apitable/issues/121)

The user cannot clear the default value of the percent field.

Because input field not check `''` value

# What?
<!-- 
> Can you describe this feature in detail?
> Who can benefit from it? 
-->
All users who adjust the percentage default can benefit from this

# How?
<!-- 
> Do you have a simple description of how this pull request is implemented?
-->
Add check `''`, when percent field update.
