### PR TITLE
fix: issue #121 percent is still 0 after emptying the default value

### DIFF
--- a/packages/datasheet/src/pc/components/editors/number_editor/number_editor.tsx
+++ b/packages/datasheet/src/pc/components/editors/number_editor/number_editor.tsx
@@ -139,7 +139,7 @@ const NumberEditorBase: React.ForwardRefRenderFunction<IEditor, INumberEditorPro
       tempVal = str2NumericStr(tempVal);
       tempVal = tempVal == null ? '' : tempVal;
       if (fieldType === FieldType.Percent) {
-        tempVal = tempVal == null ? '' : String(divide(Number(tempVal), 100));
+        tempVal = (tempVal === null || tempVal === '') ? '' : String(divide(Number(tempVal), 100));
       }
       commandFn && commandFn(tempVal);
       onChange && onChange(tempVal);


### PR DESCRIPTION

Submit a pull request for this project.

After I filled in a default value of the percent field, I couldn't get it back to the "empty" state, it always showed a "0" in the input box

# Why? 

To fix the issue: https://github.com/apitable/apitable/issues/121

The user cannot clear the default value of the percent field.

Because the input field does not check the '' value

# What?

Users who want to clear the percentage defaults will benefit from this


# How?

Just add check ''
