### PR TITLE
fix: percent field default cant set to empty in issue #121

### DIFF
--- a/packages/datasheet/src/pc/components/editors/number_editor/number_editor.tsx
+++ b/packages/datasheet/src/pc/components/editors/number_editor/number_editor.tsx
@@ -139,7 +139,7 @@ const NumberEditorBase: React.ForwardRefRenderFunction<IEditor, INumberEditorPro
       tempVal = str2NumericStr(tempVal);
       tempVal = tempVal == null ? '' : tempVal;
       if (fieldType === FieldType.Percent) {
-        tempVal = tempVal == null ? '' : String(divide(Number(tempVal), 100));
+        tempVal = tempVal === null || tempVal === '' ? '' : divide(Number(tempVal), 100) + '';
       }
       commandFn && commandFn(tempVal);
       onChange && onChange(tempVal);


### PR DESCRIPTION
Submit a pull request for this project.

<!-- If you have an Issue that related to this Pull Request, you can copy this Issue's description -->

# Why? 
<!-- 
> Related to which issue?
> Why we need this pull request?
> What is the user story for this pull request? 
-->
Fixed issue: https://github.com/apitable/apitable/issues/121

# What?
<!-- 
> Can you describe this feature in detail?
> Who can benefit from it? 
-->
This bug happens when the user enters a input value is empty, because function `divide` trying to convert empty string to number 0.


# How?
<!-- 
> Do you have a simple description of how this pull request is implemented?
-->
Add conditional judgment to filter out empty string to prevent them from being converted into number.
