### PR TITLE
fix: number_editor format empty value to '0', fix issues #121

### DIFF
--- a/packages/datasheet/src/pc/components/editors/number_editor/number_editor.tsx
+++ b/packages/datasheet/src/pc/components/editors/number_editor/number_editor.tsx
@@ -139,7 +139,7 @@ const NumberEditorBase: React.ForwardRefRenderFunction<IEditor, INumberEditorPro
       tempVal = str2NumericStr(tempVal);
       tempVal = tempVal == null ? '' : tempVal;
       if (fieldType === FieldType.Percent) {
-        tempVal = tempVal == null ? '' : String(divide(Number(tempVal), 100));
+        tempVal = tempVal == '' ? '' : String(divide(Number(tempVal), 100));
       }
       commandFn && commandFn(tempVal);
       onChange && onChange(tempVal);


### PR DESCRIPTION

Submit a pull request for this project.

<!-- If you have an Issue that related to this Pull Request, you can copy this Issue's description -->

# Why? 
<!-- 
> Related to which issue?
> Why we need this pull request?
> What is the user story for this pull request? 
-->
Fix this issues https://github.com/apitable/apitable/issues/121

# What?
<!-- 
> Can you describe this feature in detail?
> Who can benefit from it? 
-->
This commit fix the percent field, if default value was set, it cannot be set to empty. 

# How?
<!-- 
> Do you have a simple description of how this pull request is implemented?
-->

The code on line 140 sets all null values to empty strings, and the formatting method only considers the case of null values, resulting in empty strings being formatted as '0', so I changed the judgment to an empty string judgment.
