### PR TITLE
chore: disable eslint validate of super linter

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -84,3 +84,5 @@ jobs:
           VALIDATE_ALL_CODEBASE: false
           DEFAULT_BRANCH: develop
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VALIDATE_TYPESCRIPT_STANDARD: false
+          VALIDATE_TYPESCRIPT_ES: false


### PR DESCRIPTION
Submit a pull request for this project.

<!-- If you have an Issue that related to this Pull Request, you can copy this Issue's description -->

# Why? 
<!-- 
> Related to which issue?
> Why we need this pull request?
> What is the user story for this pull request? 
-->
There is action of scanning eslint, no need to validate eslint/tslint by the super linter

# What?
<!-- 
> Can you describe this feature in detail?
> Who can benefit from it? 
-->
disable eslint validate of super linter

# How?
<!-- 
> Do you have a simple description of how this pull request is implemented?
-->
set super linter env VALIDATE_TYPESCRIPT_ES and VALIDATE_TYPESCRIPT_ES to false