### PR TITLE
chore: bump dependent images

### DIFF
--- a/.env
+++ b/.env
@@ -12,11 +12,11 @@ IMAGE_ROOM_SERVER=apitable/room-server:latest
 IMAGE_SOCKET_SERVER=apitable/socket-server:latest
 IMAGE_WEB_SERVER=apitable/web-server:latest
 
-IMAGE_GATEWAY=openresty/openresty:1.21.4.1-3-buster-fat
-IMAGE_MINIO=minio/minio:RELEASE.2021-03-17T02-33-02Z
-IMAGE_MYSQL=mysql:8.0.29
-IMAGE_RABBITMQ=rabbitmq:3-management
-IMAGE_REDIS=redis:5
+IMAGE_GATEWAY=openresty/openresty:1.21.4.1-4-buster-fat
+IMAGE_MINIO=minio/minio:RELEASE.2023-01-25T00-19-54Z
+IMAGE_MYSQL=mysql:8.0.32
+IMAGE_RABBITMQ=rabbitmq:3.11.7-management
+IMAGE_REDIS=redis:7.0.8
 
 ### SERVER
 BACKEND_BASE_URL=http://backend-server:8081/api/v1/

--- a/Makefile
+++ b/Makefile
@@ -346,7 +346,7 @@ devenv-up:
 
 .PHONY: devenv-down
 devenv-down: ## debug all devenv services with docker compose up -d
-	$(_DEVENV) down -v
+	$(_DEVENV) down -v --remove-orphans
 
 devenv-logs: ## follow all devenv services logs
 	$(_DEVENV) logs -f
@@ -442,7 +442,7 @@ _dataenv-volumes: ## create data folder with current user permissions
 		$$DATA_PATH/.data/rabbitmq \
 
 dataenv-down:
-	$(_DATAENV) down -v
+	$(_DATAENV) down -v --remove-orphans
 
 dataenv-ps:
 	$(_DATAENV) ps
@@ -459,7 +459,7 @@ up: _dataenv-volumes ## startup the application
 
 .PHONY: down
 down: ## shutdown the application
-	docker compose down -v
+	docker compose down -v --remove-orphans
 
 .PHONY:ps
 ps: ## docker compose ps

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -66,29 +66,6 @@ services:
       mysql:
         condition: service_healthy
 
-  scheduler-server:
-    image: ${IMAGE_REGISTRY}/${IMAGE_ROOM_SERVER}
-    pull_policy: ${IMAGE_PULL_POLICY:-if_not_present}
-    restart: always
-    expose:
-      - "3333"
-      - "3334"
-    env_file:
-      - "${ENV_FILE:-.env}"
-    environment:
-      - NODE_ENV=${ENV}
-      - NODE_OPTIONS=--max-old-space-size=2048 --max-http-header-size=80000
-      - API_MAX_MODIFY_RECORD_COUNTS=${API_MAX_MODIFY_RECORD_COUNTS:-30}
-      - INSTANCE_MAX_MEMORY=4096M
-      - APPLICATION_NAME=SCHEDULE_SERVER
-      # only one server opened
-      - ENABLE_SCHED=true
-    networks:
-      - apitable
-    depends_on:
-      mysql:
-        condition: service_healthy
-
   socket-server:
     image: ${IMAGE_REGISTRY}/${IMAGE_SOCKET_SERVER}
     pull_policy: ${IMAGE_PULL_POLICY:-if_not_present}
@@ -131,8 +108,6 @@ services:
       backend-server:
         condition: service_healthy
       room-server:
-        condition: service_started
-      scheduler-server:
         condition: service_started
       socket-server:
         condition: service_started


### PR DESCRIPTION

Submit a pull request for this project.

<!-- If you have an Issue that related to this Pull Request, you can copy this Issue's description -->

# Why? 
<!-- 
> Related to which issue?
> Why we need this pull request?
> What is the user story for this pull request? 
-->

Dependent images are outdated and have security issues.

# What?
<!-- 
> Can you describe this feature in detail?
> Who can benefit from it? 
-->

Bump dependent images to newer ones.

# How?
<!-- 
> Do you have a simple description of how this pull request is implemented?
-->

Bump redis, minio, rabbitmq, mysql, openresty image version.

**BREAKING CHANGE**

The minio docker image upgrade contains compatibility issue with old one:

```text
apitable-minio-1  | ERROR Unable to use the drive /data: Drive /data: found backend type fs, expected xl or xl-single - to migrate to a supported backend visit https://min.io/docs/minio/linux/operations/install-deploy-manage/migrate-fs-gateway.html: Invalid arguments specified
```

Use the following commands to fix that issue if you are not interested in historical attachments:
```bash
docker compose down -v --remove-orphans
rm -fr .data/minio
docker compose up -d
```

Please refer to the official guide if you want to keep the old data:
https://min.io/docs/minio/linux/operations/install-deploy-manage/migrate-fs-gateway.html