### PR TITLE
docs: super link for architecture overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,6 +307,7 @@ APITable use these common conventions:
 - How to versioning and tagging? [Semantic Versioning](https://semver.org/)
 - What is the Java Coding Guideline? [Java Coding Guideline](https://google.github.io/styleguide/javaguide.html) | [Intellij IDEA Plugin](https://plugins.jetbrains.com/plugin/8527)
 - What is the TypeScript Coding Guideline? -> [TypeScript Style Guide](https://google.github.io/styleguide/tsguide.html) | [ESLint](https://www.npmjs.com/package/@typescript-eslint/eslint-plugin)
+- What is the Architecture Overview? -> [Understand APITable - Architecture Overview](./docs/contribute/architecute-overview.md)
 
 ### Documentations
 


### PR DESCRIPTION

Submit a pull request for this project.

<!-- If you have an Issue that related to this Pull Request, you can copy this Issue's description -->

# Why? 
<!-- 
> Related to which issue?
> Why we need this pull request?
> What is the user story for this pull request? 
-->
users like to know APITable's architecture overview

# What?
<!-- 
> Can you describe this feature in detail?
> Who can benefit from it? 
-->
already have a doc of [architecture](../../blob/develop/docs/contribute/architecute-overview.md), so we just need to link it to readme

# How?
<!-- 
> Do you have a simple description of how this pull request is implemented?
-->
add a super link to the readme for an architecture overview
