### PR TITLE
chore: keep the default settings the same with devenv

### DIFF
--- a/packages/room-server/env/.env.defaults
+++ b/packages/room-server/env/.env.defaults
@@ -16,13 +16,13 @@ MYSQL_PASSWORD=apitable@com
 MYSQL_PORT=3306
 # ms
 MYSQL_RETRY_DELAY=300
-MYSQL_USERNAME=apitable
+MYSQL_USERNAME=root
 
 # If not configured, the default is 0
 REDIS_DB=3
 # Redis configuration
 REDIS_HOST=127.0.0.1
-REDIS_PASSWORD=
+REDIS_PASSWORD=apitable@com
 REDIS_PORT=6379
 
 # SOCKET-server configuration


### PR DESCRIPTION

Submit a pull request for this project.

<!-- If you have an Issue that related to this Pull Request, you can copy this Issue's description -->

# Why? 
<!-- 
> Related to which issue?
> Why we need this pull request?
> What is the user story for this pull request? 
-->
Related to https://github.com/apitable/apitable/issues/424, the default `MYSQL_USERNAME` is incorrect in the default settings, it should be `root`