### PR TITLE
fix: robot error

### DIFF
--- a/packages/datasheet/src/pc/components/robot/robot_detail/magic_variable_container/magic_variable_container.tsx
+++ b/packages/datasheet/src/pc/components/robot/robot_detail/magic_variable_container/magic_variable_container.tsx
@@ -53,7 +53,7 @@ export const MagicVariableContainer = forwardRef((props: ISchemaMapProps, ref) =
   useEffect(() => {
     setTimeout(() => {
       searchRef.current?.focus();
-    }, 0);
+    }, 100);
   }, []);
   useEffect(() => {
     if (searchValue) {


### PR DESCRIPTION

Describe the bug

When using APITable robot, every time I enter "/' in the body by using Jason to call variables, the screen will jump wrongly. This problem makes users hardly use the robot function.

To Reproduce
Please see screen record: https://user-images.githubusercontent.com/55542378/218730816-56fd2028-875d-4c03-bbab-eb412931d790.mp4

Expected behavior
don't jump. Keep normal.

Screenshots
Please see screen record: https://user-images.githubusercontent.com/55542378/218730816-56fd2028-875d-4c03-bbab-eb412931d790.mp4

Desktop (please complete the following information):

OS: [MacOS]
Browser [chrome]
additional content
You can join my space for testing👇🏻:

https://apitable.com/invite/link?token=12340000b40d4981b6d3c01b62a4af23 From APITable: You were invited to join the "gary's Space" space by gary.

# Why? 
https://github.com/apitable/apitable/issues/372


# What?
fix the robot error


# How?
Because 'rc-trigger' can't immediately get the correct dom position
