### PR TITLE
fix: init theme in widget runtime

### DIFF
--- a/packages/datasheet/src/widget-stage/theme.ts
+++ b/packages/datasheet/src/widget-stage/theme.ts
@@ -24,7 +24,7 @@ export const initTheme = () => {
   let localTheme = localStorage.getItem('theme');
   localTheme = localTheme ? 
     (localTheme.includes(ThemeName.Dark) ? ThemeName.Dark : ThemeName.Light) : null;
-  const theme = query.get('theme') || localTheme || ThemeName.Light;
+  const theme = query.get('theme') || localTheme || getEnvVariables().SYSTEM_CONFIGURATION_DEFAULT_THEME ||ThemeName.Light;
   switchTheme(theme as ThemeName);
 };
 


### PR DESCRIPTION

Submit a pull request for this project.

<!-- If you have an Issue that related to this Pull Request, you can copy this Issue's description -->

# Why? 
<!-- 
> Related to which issue?
> Why we need this pull request?
> What is the user story for this pull request? 
-->

Fix: the widget‘s background is white

# What?
<!-- 
> Can you describe this feature in detail?
> Who can benefit from it? 
-->


# How?
<!-- 
> Do you have a simple description of how this pull request is implemented?
-->
Take the default theme color of the environment variable when initializing the theme color.