### PR TITLE
fix: avoid loading room-native-api if USE_NATIVE_MODULE is disabled

### DIFF
--- a/packages/room-server/src/database/datasheet/controllers/datasheet.controller.ts
+++ b/packages/room-server/src/database/datasheet/controllers/datasheet.controller.ts
@@ -16,22 +16,22 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { IMeta } from '@apitable/core';
+import type { IMeta } from '@apitable/core';
 import { Body, Controller, Delete, Get, Headers, Param, Post, Query, UseInterceptors } from '@nestjs/common';
 import { UserService } from 'user/services/user.service';
 import { DatasheetException, PermissionException, ServerException } from 'shared/exception';
 import { ResourceDataInterceptor } from 'database/resource/middleware/resource.data.interceptor';
-import { CommentReplyDto } from '../dtos/comment.reply.dto';
+import type { CommentReplyDto } from '../dtos/comment.reply.dto';
 import { DatasheetRecordSubscriptionBaseService } from 'database/subscription/datasheet.record.subscription.base.service';
-import { DatasheetPack, RecordsMapView, UserInfo, ViewPack } from '../../interfaces';
-import { DatasheetPackRo } from '../ros/datasheet.pack.ro';
+import type { DatasheetPack, RecordsMapView, UserInfo, ViewPack } from '../../interfaces';
+import type { DatasheetPackRo } from '../ros/datasheet.pack.ro';
 import { NodeService } from 'node/services/node.service';
 import { NodeShareSettingService } from 'node/services/node.share.setting.service';
 import { DatasheetMetaService } from '../services/datasheet.meta.service';
 import { DatasheetRecordService } from '../services/datasheet.record.service';
 import { DatasheetService } from '../services/datasheet.service';
 import { MetaService } from 'database/resource/services/meta.service';
-import { DatasheetPackResponse } from '@apitable/room-native-api';
+import type { DatasheetPackResponse } from '@apitable/room-native-api';
 
 /**
  * Datasheet APIs

--- a/packages/room-server/src/database/datasheet/services/datasheet.service.ts
+++ b/packages/room-server/src/database/datasheet/services/datasheet.service.ts
@@ -30,13 +30,13 @@ import {
 } from '@apitable/core';
 import { Span } from '@metinseylan/nestjs-opentelemetry';
 import { forwardRef, Inject, Injectable } from '@nestjs/common';
-import { DatasheetEntity } from '../entities/datasheet.entity';
+import type { DatasheetEntity } from '../entities/datasheet.entity';
 import { CommandService } from 'database/command/services/command.service';
 import { isEmpty } from 'lodash';
-import { Store } from 'redux';
+import type { Store } from 'redux';
 import { InjectLogger, USE_NATIVE_MODULE } from 'shared/common';
 import { DatasheetException, ServerException } from 'shared/exception';
-import {
+import type {
   IAuthHeader,
   IFetchDataOptions,
   IFetchDataOriginOptions,
@@ -45,7 +45,7 @@ import {
   ILoadBasePackOptions,
 } from 'shared/interfaces';
 import { Logger } from 'winston';
-import { DatasheetPack, UnitInfo, UserInfo, ViewPack } from '../../interfaces';
+import type { DatasheetPack, UnitInfo, UserInfo, ViewPack } from '../../interfaces';
 import { DatasheetRepository } from '../repositories/datasheet.repository';
 import { NodeService } from 'node/services/node.service';
 import { UserService } from '../../../user/services/user.service';
@@ -53,7 +53,7 @@ import { DatasheetFieldHandler } from './datasheet.field.handler';
 import { DatasheetMetaService } from './datasheet.meta.service';
 import { DatasheetRecordService } from './datasheet.record.service';
 import { MetaService } from 'database/resource/services/meta.service';
-import { DatasheetPackResponse } from '@apitable/room-native-api';
+import type { DatasheetPackResponse } from '@apitable/room-native-api';
 import { NativeService } from 'shared/services/native/native.service';
 
 @Injectable()

--- a/packages/room-server/src/database/mirror/controllers/mirror.controller.ts
+++ b/packages/room-server/src/database/mirror/controllers/mirror.controller.ts
@@ -18,14 +18,14 @@
 
 import { Controller, Headers, Get, Param, UseInterceptors, Query, Body, Post, Delete } from '@nestjs/common';
 import { ResourceDataInterceptor } from 'database/resource/middleware/resource.data.interceptor';
-import { DatasheetPack, MirrorInfo } from '../../interfaces';
+import type { DatasheetPack, MirrorInfo } from '../../interfaces';
 import { DatasheetRecordSubscriptionBaseService } from 'database/subscription/datasheet.record.subscription.base.service';
 import { MirrorService } from 'database/mirror/services/mirror.service';
 import { NodeService } from 'node/services/node.service';
 import { NodeShareSettingService } from 'node/services/node.share.setting.service';
 import { UserService } from 'user/services/user.service';
-import { DatasheetPackRo } from '../../datasheet/ros/datasheet.pack.ro';
-import { DatasheetPackResponse } from '@apitable/room-native-api';
+import type { DatasheetPackRo } from '../../datasheet/ros/datasheet.pack.ro';
+import type { DatasheetPackResponse } from '@apitable/room-native-api';
 
 /**
  * mirror interface

--- a/packages/room-server/src/database/mirror/services/mirror.service.ts
+++ b/packages/room-server/src/database/mirror/services/mirror.service.ts
@@ -18,15 +18,15 @@
 
 import { Span } from '@metinseylan/nestjs-opentelemetry';
 import { Injectable } from '@nestjs/common';
-import { IPermissions } from '@apitable/core';
+import type { IPermissions } from '@apitable/core';
 import { DatasheetException } from '../../../shared/exception';
-import { IFetchDataOriginOptions, IAuthHeader } from '../../../shared/interfaces';
+import type { IFetchDataOriginOptions, IAuthHeader } from '../../../shared/interfaces';
 import { omit } from 'lodash';
-import { DatasheetPack, MirrorInfo } from '../../interfaces';
+import type { DatasheetPack, MirrorInfo } from '../../interfaces';
 import { DatasheetService } from 'database/datasheet/services/datasheet.service';
 import { NodeService } from 'node/services/node.service';
 import { ResourceMetaRepository } from 'database/resource/repositories/resource.meta.repository';
-import { DatasheetPackResponse } from '@apitable/room-native-api';
+import type { DatasheetPackResponse } from '@apitable/room-native-api';
 
 @Injectable()
 export class MirrorService {

--- a/packages/room-server/src/database/resource/controllers/resource.controller.ts
+++ b/packages/room-server/src/database/resource/controllers/resource.controller.ts
@@ -31,10 +31,10 @@ import { ApiResponse } from 'fusion/vos/api.response';
 import { RecordHistoryTypeEnum } from 'shared/enums/record.history.enum';
 import { PermissionException, ServerException } from 'shared/exception';
 import { ResourceDataInterceptor } from 'database/resource/middleware/resource.data.interceptor';
-import { ChangesetView, DatasheetPack } from '../../interfaces';
-import { RecordHistoryQueryRo } from '../../datasheet/ros/record.history.query.ro';
-import { RecordHistoryVo } from '../vos/record.history.vo';
-import { DatasheetPackResponse } from '@apitable/room-native-api';
+import type { ChangesetView, DatasheetPack } from '../../interfaces';
+import type { RecordHistoryQueryRo } from '../../datasheet/ros/record.history.query.ro';
+import type { RecordHistoryVo } from '../vos/record.history.vo';
+import type { DatasheetPackResponse } from '@apitable/room-native-api';
 
 @Controller('nest/v1')
 export class ResourceController {

--- a/packages/room-server/src/database/resource/middleware/resource.data.interceptor.ts
+++ b/packages/room-server/src/database/resource/middleware/resource.data.interceptor.ts
@@ -19,13 +19,13 @@
 import { Injectable, NestInterceptor, Logger, ExecutionContext, CallHandler } from '@nestjs/common';
 import { ResourceType, ResourceIdPrefix, IWidget, IWidgetPanel } from '@apitable/core';
 import { InjectLogger } from '../../../shared/common';
-import { Observable } from 'rxjs';
+import type { Observable } from 'rxjs';
 import { tap } from 'rxjs/operators';
-import { IResourceDataInfo as IResourceInfo } from './interface';
+import type { IResourceDataInfo as IResourceInfo } from './interface';
 import { NodeService } from 'node/services/node.service';
 import { RoomResourceRelService } from 'database/resource/services/room.resource.rel.service';
-import { DashboardDataPack, DatasheetPack, FormDataPack, MirrorInfo } from 'database/interfaces';
-import { DatasheetPackResponse } from '@apitable/room-native-api';
+import type { DashboardDataPack, DatasheetPack, FormDataPack, MirrorInfo } from 'database/interfaces';
+import type { DatasheetPackResponse } from '@apitable/room-native-api';
 
 /**
  * Resource data interceptor

--- a/packages/room-server/src/database/resource/services/resource.service.ts
+++ b/packages/room-server/src/database/resource/services/resource.service.ts
@@ -27,7 +27,7 @@ import { DatasheetService } from '../../datasheet/services/datasheet.service';
 import { NodeService } from '../../../node/services/node.service';
 import { WidgetService } from '../../widget/services/widget.service';
 import { DatasheetPack } from 'database/interfaces';
-import { DatasheetPackResponse } from '@apitable/room-native-api';
+import type { DatasheetPackResponse } from '@apitable/room-native-api';
 
 @Injectable()
 export class ResourceService {

--- a/packages/room-server/src/shared/services/native/native.service.ts
+++ b/packages/room-server/src/shared/services/native/native.service.ts
@@ -1,8 +1,8 @@
 import { Injectable } from '@nestjs/common';
-import { NativeModule, DatasheetPackResponse } from '@apitable/room-native-api';
+import type { NativeModule, DatasheetPackResponse } from '@apitable/room-native-api';
 import { isDevMode } from 'app.environment';
 import { DEFAULT_EDITOR_PERMISSION, DEFAULT_MANAGER_PERMISSION, DEFAULT_PERMISSION, DEFAULT_READ_ONLY_PERMISSION, IRecordMap } from '@apitable/core';
-import { IAuthHeader, IFetchDataOptions, IFetchDataOriginOptions, IFetchDataPackOptions, IOssConfig } from 'shared/interfaces';
+import type { IAuthHeader, IFetchDataOptions, IFetchDataOriginOptions, IFetchDataPackOptions, IOssConfig } from 'shared/interfaces';
 import { HttpService } from '@nestjs/axios';
 import { CommonException, PermissionException, ServerException } from 'shared/exception';
 import { Logger } from 'winston';
@@ -18,7 +18,7 @@ export class NativeService {
 
   constructor(httpService: HttpService, envConfigService: EnvConfigService, @InjectLogger() private readonly logger: Logger) {
     if (USE_NATIVE_MODULE) {
-      this.nativeModule = NativeModule.create(
+      this.nativeModule = require('@apitable/room-native-api').NativeModule.create(
         isDevMode,
         httpService.axiosRef.defaults.baseURL!,
         envConfigService.getRoomConfig(EnvConfigKey.OSS) as IOssConfig,


### PR DESCRIPTION
Currently the `room-native-api` package is still loaded if the `USE_NATIVE_MODULE` env var is disabled, which can lead to glibc version mismatching in the all-in-one image, that is, all-in-one image has glibc 2.29, but room-native-api is compiled against glibc 2.28. This problem is fixed by avoiding `require`ing `room-native-api` at runtime if `USE_NATIVE_MODULE` is disabled.