### PR TITLE
fix: disable forbid unknow values

### DIFF
--- a/packages/room-server/src/main.ts
+++ b/packages/room-server/src/main.ts
@@ -65,6 +65,7 @@ async function bootstrap() {
     new ValidationPipe({
       transform: true,
       stopAtFirstError: true,
+      forbidUnknownValues: false,
     }),
   );
 


### PR DESCRIPTION
Due to [a deserialization issue](https://github.com/typestack/class-validator/issues/1873) caused by `class-validator` `0.14.0`, disable `forbidUnknownValues` for a short-term solution.