### PR TITLE
fix: remove pre-init-db since upgrade liquibase

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -186,24 +186,6 @@ services:
       - apitable
 
   # init data
-  pre-init-db:
-    image: ${IMAGE_REGISTRY}/${IMAGE_INIT_DB}
-    pull_policy: ${IMAGE_PULL_POLICY:-if_not_present}
-    environment:
-      - TZ=${TIMEZONE}
-      - DB_HOST=${MYSQL_HOST}
-      - DB_PORT=${MYSQL_PORT}
-      - DB_NAME=${MYSQL_DATABASE}
-      - DB_USERNAME=${MYSQL_USERNAME}
-      - DB_PASSWORD=${MYSQL_PASSWORD}
-      - DATABASE_TABLE_PREFIX=${DATABASE_TABLE_PREFIX}
-      - ACTION=releaseLocks
-    networks:
-      - apitable
-    depends_on:
-      mysql:
-        condition: service_healthy
-  
   init-db:
     image: ${IMAGE_REGISTRY}/${IMAGE_INIT_DB}
     pull_policy: ${IMAGE_PULL_POLICY:-if_not_present}
@@ -219,8 +201,8 @@ services:
     networks:
       - apitable
     depends_on:
-      pre-init-db:
-        condition: service_completed_successfully
+      mysql:
+        condition: service_healthy
 
   # init-appdata
   init-appdata:


### PR DESCRIPTION
# Why? 
error to run `releaseLocks` execution command  on pre-init-db container


# What?
because latest liquibase image version don't support command arguments for `releaseLocks`


# How?
delete pre-init-db container for running project on start up, liquibase image has increase latest version for support linux/arm64 machine
