### PR TITLE
chore: add config for specifying rust version

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly"


### PR DESCRIPTION
Add rust version config file to the repo so that users don't need to run `rustup default nightly` each time before building APITable, and they are free to use other rust versions in other projects.