### PR TITLE
fix: fix scrollbar's bg style (#5138)

### DIFF
--- a/packages/datasheet/.eslintrc
+++ b/packages/datasheet/.eslintrc
@@ -11,7 +11,14 @@
     "react/display-name": 0,
     "react/no-find-dom-node": 0,
     "@next/next/no-html-link-for-pages": ["error", "packages/datasheet/pages/"],
-    "@next/next/no-img-element": "off"
+    "@next/next/no-img-element": "off",
+    "no-restricted-imports": ["error", {
+      "paths": [{
+        "name": "react-custom-scrollbars",
+        "importNames": ["Scrollbars"],
+        "message": "Please use ScrollBar from pc/components/scroll_bar instead."
+      }]
+    }]
 //    "@typescript-eslint/no-misused-promises": 1,
 //    "@typescript-eslint/no-floating-promises": 1
   }

--- a/packages/datasheet/src/pc/components/dashboard_panel/recommend_widget_panel/recommend_widget_panel.tsx
+++ b/packages/datasheet/src/pc/components/dashboard_panel/recommend_widget_panel/recommend_widget_panel.tsx
@@ -24,13 +24,13 @@ import { Message, Tooltip } from 'pc/components/common';
 import { SearchPanel, SubColumnType } from 'pc/components/datasheet_search_panel';
 import * as React from 'react';
 import { useEffect, useState } from 'react';
-import { Scrollbars } from 'react-custom-scrollbars';
 import { useSelector } from 'react-redux';
 import NotDataImgDark from 'static/icon/datasheet/empty_state_dark.png';
 import NotDataImgLight from 'static/icon/datasheet/empty_state_light.png';
 import styles from './style.module.less';
 import { getUrlWithHost } from 'pc/utils';
 import { createWidgetByExistWidgetId } from '../utils';
+import { ScrollBar } from '../../scroll_bar';
 
 interface IRecommendWidgetPanelProps {
   setVisibleRecommend: React.Dispatch<React.SetStateAction<boolean>>;
@@ -139,7 +139,7 @@ export const RecommendWidgetPanel: React.FC<React.PropsWithChildren<IRecommendWi
               </span>
             }
           </div>
-          <Scrollbars style={{ width: '100%', height: 222 }}>
+          <ScrollBar style={{ width: '100%', height: 222 }}>
             <main>
               {
                 recommendList.length ? recommendList.map(item => {
@@ -182,7 +182,7 @@ export const RecommendWidgetPanel: React.FC<React.PropsWithChildren<IRecommendWi
                   </span>
               }
             </main>
-          </Scrollbars>
+          </ScrollBar>
         </>
     }
     {

--- a/packages/datasheet/src/pc/components/scroll_bar.tsx
+++ b/packages/datasheet/src/pc/components/scroll_bar.tsx
@@ -16,6 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+// eslint-disable-next-line no-restricted-imports
 import { Scrollbars } from 'react-custom-scrollbars';
 import { FC } from 'react';
 import * as React from 'react';
@@ -33,9 +34,9 @@ export const ScrollBar: FC<React.PropsWithChildren<ICustomScrollbarsProps>> = (p
   const renderThumb = ({ style, ...props }: any) => {
     const thumbStyle = {
       borderRadius: 6,
-      backgroundColor: 'rgba(191, 193, 203, 0.5)',
       zIndex: 1,
       opacity: (!autoHide || isHovering) ? '1' : '0',
+      background: 'var(--bgScrollbarDefault)',
     };
     return <div style={{ ...style, ...thumbStyle }} {...props} />;
   };

--- a/packages/datasheet/src/pc/components/space_manage/role/content/left.tsx
+++ b/packages/datasheet/src/pc/components/space_manage/role/content/left.tsx
@@ -22,6 +22,7 @@ import { AddOutlined, DeleteOutlined, EditOutlined } from '@apitable/icons';
 import { Avatar, AvatarSize, AvatarType, SearchEmpty, SearchInput } from 'pc/components/common';
 import { Modal } from 'pc/components/common/modal/modal/modal';
 import { useContext, useEffect, useMemo, useState } from 'react';
+// eslint-disable-next-line no-restricted-imports
 import { Scrollbars } from 'react-custom-scrollbars';
 
 import { RoleContext } from '../context';

--- a/packages/datasheet/src/pc/components/widget/widget_center/widget_center.tsx
+++ b/packages/datasheet/src/pc/components/widget/widget_center/widget_center.tsx
@@ -33,9 +33,11 @@ import { store } from 'pc/store';
 import { getEnvVariables } from 'pc/utils/env';
 import * as React from 'react';
 import { CSSProperties, useCallback, useEffect, useRef, useState } from 'react';
+// eslint-disable-next-line no-restricted-imports
 import { Scrollbars } from 'react-custom-scrollbars';
 import { createRoot } from 'react-dom/client';
 import { Provider, useSelector } from 'react-redux';
+import { ScrollBar } from '../../scroll_bar';
 import WidgetCenterEmptyDark from 'static/icon/datasheet/widget_center_empty_dark.png';
 import WidgetCenterEmptyLight from 'static/icon/datasheet/widget_center_empty_light.png';
 
@@ -189,7 +191,7 @@ export const WidgetCenterModal: React.FC<React.PropsWithChildren<IWidgetCenterMo
     const thumbStyle = {
       right: 4,
       borderRadius: 'inherit',
-      backgroundColor: 'rgba(0,0,0,0.2)',
+      background: 'var(--bgScrollbarDefault)',
     };
     return <div style={{ ...style, ...thumbStyle }} {...props} />;
   };
@@ -233,10 +235,9 @@ export const WidgetCenterModal: React.FC<React.PropsWithChildren<IWidgetCenterMo
         className={styles.widgetCenterModalTab}
       >
         <TabPane tab={t(Strings.widget_center_tab_official)} key={WidgetReleaseType.Global}>
-          <Scrollbars renderThumbVertical={renderThumb} style={{ width: '100%', height: '100%' }}>
+          <ScrollBar style={{ width: '100%', height: '100%' }}>
 
             <TabItemIntroduction introduction={t(Strings.widget_center_official_introduction)} />
-
             {
               loading ? <div className={styles.skeletonWrap}>
                 <Skeleton count={1} width='38%' />
@@ -250,7 +251,7 @@ export const WidgetCenterModal: React.FC<React.PropsWithChildren<IWidgetCenterMo
                 showMenu={showMenu}
               />
             }
-          </Scrollbars>
+          </ScrollBar>
         </TabPane>
         {
           getEnvVariables().CUSTOM_WIDGET_VISIBLE &&


### PR DESCRIPTION
Fix  incorrect bgcolor of scrollbar

<!-- If you have an Issue that related to this Pull Request, you can copy this Issue's description -->

# Why? 
<!-- 
> Related to which issue?
> Why we need this pull request?
> What is the user story for this pull request? 
-->

close #5138


# What?
<!-- 
> Can you describe this feature in detail?
> Who can benefit from it? 
-->
1.   The background color of the scroll bar is hard coded.

# How?
<!-- 
> Do you have a simple description of how this pull request is implemented?
-->

1. set bgColor of thumbStyle to ```var(--bgScrollbarDefault)```
2. add eslint rule, restrict direct import from ```react-custom-scrollbars```

<img width="1009" alt="image" src="https://github.com/apitable/apitable/assets/12862508/4e6c33c2-9f1e-43ee-aa0d-a1feffe7f9a4">

<img width="1029" alt="image" src="https://github.com/apitable/apitable/assets/12862508/09dfe0d2-c02a-4eb4-b6ef-f7a6800055fb">
