### PR TITLE
fix: fix dashboard connected for widget  #5133

### DIFF
--- a/packages/datasheet/src/pc/components/widget/widget_panel/widget_item/widget_block_main.tsx
+++ b/packages/datasheet/src/pc/components/widget/widget_panel/widget_item/widget_block_main.tsx
@@ -50,6 +50,18 @@ export const WidgetBlockMainBase: React.ForwardRefRenderFunction<IWidgetBlockRef
     return sourceId?.startsWith('mir') ? Selectors.getMirrorErrorCode(state, sourceId) : Selectors.getDatasheetErrorCode(state, datasheetId);
   });
 
+  const dashboardConnected = useSelector(state => {
+    try {
+      const dashboardId = state.pageParams.dashboardId;
+      if(!dashboardId ) {
+        return false;
+      }
+      return Selectors.getDashboardPack(state, nodeId)?.connected;
+    } catch (error) {
+      return false;
+    }
+  });
+  
   const nodeConnected = useSelector(state => {
     const datasheet = Selectors.getDatasheet(state, nodeId);
     const bindDatasheetLoaded = datasheet && !datasheet.isPartOfData;
@@ -97,7 +109,7 @@ export const WidgetBlockMainBase: React.ForwardRefRenderFunction<IWidgetBlockRef
     const foreignDatasheetIds = getDependenceByDstIds(state, datasheetId);
     const widgetStore = initWidgetStore(initRootWidgetState(state, widgetId, { foreignDatasheetIds }), widgetId);
     setWidgetStore(widgetStore);
-  }, [widgetId, nodeConnected]);
+  }, [widgetId, nodeConnected, dashboardConnected]);
 
   useEffect(() => {
     eventMessage.onSyncCmdOptions(widgetId, async res => {


### PR DESCRIPTION
Submit a pull request for this project.

<!-- If you have an Issue that related to this Pull Request, you can copy this Issue's description -->

# Why? 
<!-- 
> Related to which issue?
> Why we need this pull request?
> What is the user story for this pull request? 
-->

```initRootWidgetState``` requre dashboard connected .

![image](https://github.com/apitable/apitable/assets/12862508/1ca74e1d-c5b9-4a7b-9c4b-3c40c3bd3051)

init redux store for widget permission

# What?
<!-- 
> Can you describe this feature in detail?
> Who can benefit from it? 
-->


# How?
<!-- 
> Do you have a simple description of how this pull request is implemented?
-->

close #5133
