### PR TITLE
feat: enable experimental multi-arch build for linux/amd64 and linux/arm64

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -71,6 +71,10 @@ jobs:
     steps:
       - name: Fetch Sources
         uses: actions/checkout@v3
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
       - name: Build APITable and Push
         run: |
           eval "$(./scripts/semver-ci.sh)"

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -20,6 +20,7 @@ target "backend-server" {
   args = {
     SEMVER_FULL = SEMVER_FULL
   }
+  platforms = ["linux/amd64", "linux/arm64"]
   tags = ["${IMAGE_REGISTRY}/apitable/backend-server:latest", "${IMAGE_REGISTRY}/apitable/backend-server:${IMAGE_TAG}"]
 }
 
@@ -29,6 +30,7 @@ target "room-server" {
   args = {
     SEMVER_FULL = SEMVER_FULL
   }
+  platforms = ["linux/amd64", "linux/arm64"]
   tags = ["${IMAGE_REGISTRY}/apitable/room-server:latest", "${IMAGE_REGISTRY}/apitable/room-server:${IMAGE_TAG}"]
 }
 
@@ -38,6 +40,7 @@ target "web-server" {
   args = {
     SEMVER_FULL = SEMVER_FULL
   }
+  platforms = ["linux/amd64", "linux/arm64"]
   tags = ["${IMAGE_REGISTRY}/apitable/web-server:latest", "${IMAGE_REGISTRY}/apitable/web-server:${IMAGE_TAG}"]
 }
 
@@ -47,6 +50,7 @@ target "init-db" {
   args = {
     SEMVER_FULL = SEMVER_FULL
   }
+  platforms = ["linux/amd64", "linux/arm64"]
   tags = ["${IMAGE_REGISTRY}/apitable/init-db:latest", "${IMAGE_REGISTRY}/apitable/init-db:${IMAGE_TAG}"]
 }
 
@@ -56,6 +60,7 @@ target "openresty" {
   args = {
     SEMVER_FULL = SEMVER_FULL
   }
+  platforms = ["linux/amd64", "linux/arm64"]
   tags = ["${IMAGE_REGISTRY}/apitable/openresty:latest", "${IMAGE_REGISTRY}/apitable/openresty:${IMAGE_TAG}"]
 }
 
@@ -66,5 +71,6 @@ target "all-in-one" {
     SEMVER_FULL = SEMVER_FULL
     IMAGE_TAG = IMAGE_TAG
   }
+  platforms = ["linux/amd64"]
   tags = ["${IMAGE_REGISTRY}/apitable/all-in-one:latest", "${IMAGE_REGISTRY}/apitable/all-in-one:${IMAGE_TAG}"]
 }


### PR DESCRIPTION
Building multi-arch docker image via QEMU emulation is pretty slow, but let's test the build process, if they are too slow maybe we will disable them.

References:
- https://community.ibm.com/community/user/powerdeveloper/blogs/siddhesh-ghadi/2023/02/08/build-multi-arch-images-on-github-actions-with-bui
- https://docs.docker.com/build/ci/github-actions/
- https://docs.docker.com/build/building/multi-platform/

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

Release Notes:
- New Feature: Experimental multi-architecture builds for `linux/amd64` and `linux/arm64` have been enabled in Dockerfile build targets.
- New Feature: QEMU and Docker Buildx have been set up to enable experimental multi-arch builds for `linux/amd64` and `linux/arm64`.

> "Building with grace, 
> Multi-arch takes its place. 
> Linux/amd64 and arm64, 
> Docker's power we explore. 🐳"
<!-- end of auto-generated comment: release notes by openai -->