### PR TITLE
fix: remove the deprecated vscode extension

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -5,7 +5,6 @@
     "arcanis.vscode-zipfs",
     "dbaeumer.vscode-eslint",
     "stylelint.vscode-stylelint",
-    "ms-vscode.vscode-typescript-tslint-plugin",
     "streetsidesoftware.code-spell-checker",
     "styled-components.vscode-styled-components",
     "sonarsource.sonarlint-vscode",


### PR DESCRIPTION

Submit a pull request for this project.


# Why? 
[TSLint has been deprecated](https://medium.com/palantir/tslint-in-2019-1a144c2317a9)

# What?

# How?
Remove the deprecated VSCode extension
