### PR TITLE
fix: share crash

### DIFF
--- a/packages/datasheet/src/pc/components/catalog/share_node/public_link/public_share_invite_link.tsx
+++ b/packages/datasheet/src/pc/components/catalog/share_node/public_link/public_share_invite_link.tsx
@@ -398,11 +398,11 @@ export const PublicShareInviteLink: FC<React.PropsWithChildren<IPublicShareLinkP
           </Tooltip>
 
         </ComponentDisplay>
-        <WidgetEmbed
+        {WidgetEmbed && <WidgetEmbed
           visible={WidgetEmbedVisible}
           hide={hideShareCodeModal}
           shareId={shareSettings.shareId}
-        />
+        />}
       </div>
     </div>
   );


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

**Refactor:**
- Updated the rendering logic for `WidgetEmbed` component in `public_share_invite_link.tsx`. The component will now only render when `WidgetEmbed` is truthy, improving performance and reducing unnecessary renders.

> 🎉 Here's to the code that's lean and mean,
> 
> To the refactor that made our UI clean. 🖥️
> 
> With `WidgetEmbed` now smartly shown, 🧠
> 
> Our app's performance has clearly grown! 🚀
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->