### PR TITLE
fix: fusion path proxy

### DIFF
--- a/packages/datasheet/server.js
+++ b/packages/datasheet/server.js
@@ -50,7 +50,7 @@ app.prepare().then(() => {
     );
 
     server.use(createProxyMiddleware('/fusion', {
-        target: process.env.API_PROXY || process.env.API_FUSION_SERVER || 'http://127.0.0.1',
+        target: process.env.API_PROXY || process.env.API_FUSION_SERVER || 'http://127.0.0.1:3333',
         changeOrigin: true,
         cookieDomainRewrite: '',
       })


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- Refactor: Updated the target URL for the proxy middleware in our Express server. This change will redirect all API requests to `'http://127.0.0.1:3333'` by default, improving the consistency and reliability of our backend services. Please ensure your local development environment is set up to handle requests on this port.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->