### PR TITLE
Fix broken git hook scripts

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,7 +2,7 @@
 
 . "$(dirname "$0")/_/husky.sh"
 # npx lint-staged
-function check_forbidden_folder() {
+check_forbidden_folder() {
   local forbidden_folder="$1"
   if git diff --cached --name-only | grep -q "$forbidden_folder"; then
     echo "Error: Files in $forbidden_folder cannot be committed"

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "test:ut:room:cov": "nx test:ut:cov @apitable/room-server",
     "clear:cache": "rm -rf ./package/datasheet/node_modules/.cache/hard-source",
     "link:widget": "pnpm link @apitable/core && pnpm link @apitable/widget-sdk && pnpm link @apitable/components && pnpm link @apitable/icons",
-    "postinstall": "cd .. && husky install apitable/.husky",
+    "postinstall": "husky install .husky",
     "stylelint:datasheet": "nx stylelint @apitable/datasheet",
     "lint": "NODE_OPTIONS=--max-old-space-size=8192 eslint --config .eslintrc --ext packages/*/src/**/*.{js,ts,tsx} --format @microsoft/eslint-formatter-sarif --output-file eslint-results.sarif",
     "cy:open": "nx cy:open @apitable/cypress",


### PR DESCRIPTION

Submit a pull request for this project.

<!-- If you have an Issue that related to this Pull Request, you can copy this Issue's description -->

# Why? 
<!-- 
> Related to which issue?
> Why we need this pull request?
> What is the user story for this pull request? 
-->
There is an issue: https://github.com/apitable/apitable/issues/1493. These two patches fix it.


# What?
<!-- 
> Can you describe this feature in detail?
> Who can benefit from it? 
-->
Make existing git hooks functional, instead of being ignored.


# How?
<!-- 
> Do you have a simple description of how this pull request is implemented?
-->
1. All scripts specified in `package.json` share the same working directory, which is project root, according to the last point of https://docs.npmjs.com/cli/v10/using-npm/scripts/#best-practices
2. There is an error for currect pre-commit hook:`.husky/pre-commit: 5: Syntax error: "(" unexpected`. This is due to the fact that keyword `function` is not conform to the standard shell grammar, according to https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_09_05
