### PR TITLE
Refactor betweenTest and distinctIgnoreCase

### DIFF
--- a/backend-server/application/src/main/java/com/apitable/shared/util/CollectionUtil.java
+++ b/backend-server/application/src/main/java/com/apitable/shared/util/CollectionUtil.java
@@ -29,6 +29,8 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.util.function.Function;
 import java.util.function.Predicate;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.util.CollectionUtils;
 
 /**
  * collection util.
@@ -63,21 +65,29 @@ public class CollectionUtil {
      * @param collection string collection
      * @return new string list
      */
-    public static ArrayList<String> distinctIgnoreCase(Collection<String> collection) {
-        if (collection == null || collection.isEmpty()) {
+    public static List<String> distinctIgnoreCase(Collection<String> collection) {
+        if (CollectionUtils.isEmpty(collection)) {
             return new ArrayList<>();
-        } else {
-            Set<String> sets = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
-            sets.addAll(collection);
-            ArrayList<String> list = new ArrayList<>();
-            for (String coll : collection) {
-                boolean containsSearchStr = sets.stream().anyMatch(coll::equals);
-                if (containsSearchStr) {
-                    list.add(coll);
-                }
-            }
-            return list;
         }
+
+        Set<String> caseInsensitiveSet = caseInsensitiveSetOf(collection);
+        return filterAndCollect(collection, caseInsensitiveSet);
+    }
+
+    private static Set<String> caseInsensitiveSetOf(Collection<String> collection) {
+        Set<String> caseInsensitiveSet = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
+        caseInsensitiveSet.addAll(collection);
+        return caseInsensitiveSet;
+    }
+
+    private static boolean containsSearchStr(String coll, Set<String> sets) {
+        return sets.stream().anyMatch(coll::equals);
+    }
+
+    private static List<String> filterAndCollect(Collection<String> collection, Set<String> caseInsensitiveSet) {
+        return collection.stream()
+            .filter(coll -> containsSearchStr(coll, caseInsensitiveSet))
+            .toList();
     }
 
     /**

--- a/backend-server/shared/core/src/test/java/com/apitable/core/util/DateTimeUtilTests.java
+++ b/backend-server/shared/core/src/test/java/com/apitable/core/util/DateTimeUtilTests.java
@@ -133,14 +133,14 @@ class DateTimeUtilTests {
             ).map(differenceTime -> DynamicTest.dynamicTest(String.format("%s natural time difference between %s and %s", differenceTime.expectDifferenceNaturalTime, startDateTime, differenceTime.endDateTime()),
                 () -> Assertions.assertEquals(differenceTime.expectDifferenceNaturalTime(), DateTimeUtil.between(startDateTime, differenceTime.endDateTime(), ChronoField.EPOCH_DAY))));
         }
-    }
 
-    private record DifferenceTime(int expectDifferenceNaturalTime, int year, int month, int dayOfMonth, int hour,
-                                  int minute, int second) {
-        LocalDateTime endDateTime(){
-            return LocalDateTime.of(year, month, dayOfMonth, hour, minute, second);
+        private record DifferenceTime(int expectDifferenceNaturalTime, int year, int month, int dayOfMonth, int hour,
+                                      int minute, int second) {
+            LocalDateTime endDateTime(){
+                return LocalDateTime.of(year, month, dayOfMonth, hour, minute, second);
+            }
+
         }
-
     }
 
     @Test

--- a/backend-server/shared/core/src/test/java/com/apitable/core/util/DateTimeUtilTests.java
+++ b/backend-server/shared/core/src/test/java/com/apitable/core/util/DateTimeUtilTests.java
@@ -25,14 +25,21 @@ import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.temporal.ChronoField;
 
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestFactory;
 
 import static com.apitable.core.util.DateTimeUtil.localDateToSecond;
 
 /**
  * <p>
- *  date time util's test
+ * date time util's test
  * </p>
  */
 class DateTimeUtilTests {
@@ -92,44 +99,53 @@ class DateTimeUtilTests {
         Assertions.assertNull(localDateTime);
     }
 
-    @Test
-    void betweenTest() {
-        LocalDateTime startDateTime = LocalDateTime.of(2022, 7, 29 , 18, 34, 20);
-        LocalDateTime endDateTime1 = LocalDateTime.of(2022, 7, 29 , 18, 34, 21);
-        LocalDateTime endDateTime2 = LocalDateTime.of(2022, 7, 30 , 0, 0, 0);
-        LocalDateTime endDateTime3 = LocalDateTime.of(2022, 7, 30 , 18, 34, 19);
-        LocalDateTime endDateTime4 = LocalDateTime.of(2022, 7, 30 , 18, 34, 20);
-        LocalDateTime endDateTime5 = LocalDateTime.of(2022, 7, 30 , 18, 34, 21);
-        LocalDateTime endDateTime6 = LocalDateTime.of(2022, 7, 31 , 0, 0, 0);
-        LocalDateTime endDateTime7 = LocalDateTime.of(2022, 8, 1 , 0, 0, 0);
-        long betweenDays = DateTimeUtil.between(startDateTime, startDateTime, ChronoField.EPOCH_DAY);
-        Assertions.assertEquals(0, betweenDays);
+    @Nested
+    class BetweenTest {
 
-        betweenDays = DateTimeUtil.between(startDateTime, endDateTime1, ChronoField.EPOCH_DAY);
-        Assertions.assertEquals(0, betweenDays);
+        private final LocalDateTime startDateTime = LocalDateTime.of(2022, 7, 29, 18, 34, 20);
 
-        betweenDays = DateTimeUtil.between(startDateTime, endDateTime2, ChronoField.EPOCH_DAY);
-        Assertions.assertEquals(1, betweenDays);
+        @TestFactory
+        Stream<DynamicTest> endDateTimeLessStartDateTime() {
+            return Stream.of(
+                new DifferenceTime(0, 2022, 7, 29, 18, 34, 19),
+                new DifferenceTime(0, 2022, 7, 29, 0, 0, 0),
+                new DifferenceTime(-1, 2022, 7, 28, 18, 34, 20),
+                new DifferenceTime(-2, 2022, 7, 27, 18, 34, 20)
+            ).map(differenceTime -> DynamicTest.dynamicTest(String.format("%s natural time difference between %s and %s", differenceTime.expectDifferenceNaturalTime, startDateTime, differenceTime.endDateTime()),
+                () -> Assertions.assertEquals(differenceTime.expectDifferenceNaturalTime(), DateTimeUtil.between(startDateTime, differenceTime.endDateTime(), ChronoField.EPOCH_DAY))));
+        }
 
-        betweenDays = DateTimeUtil.between(startDateTime, endDateTime3, ChronoField.EPOCH_DAY);
-        Assertions.assertEquals(1, betweenDays);
+        @Test
+        void return0WhenStartDateTimeEqualsEndDateTime() {
+            Assertions.assertEquals(0, DateTimeUtil.between(startDateTime, startDateTime, ChronoField.EPOCH_DAY));
+        }
 
-        betweenDays = DateTimeUtil.between(startDateTime, endDateTime4, ChronoField.EPOCH_DAY);
-        Assertions.assertEquals(1, betweenDays);
+        @TestFactory
+        Stream<DynamicTest> endDateTimeGreaterStartDateTime() {
+            return Stream.of(
+                new DifferenceTime(0, 2022, 7, 29, 18, 34, 21),
+                new DifferenceTime(1, 2022, 7, 30, 0, 0, 0),
+                new DifferenceTime(1, 2022, 7, 30, 18, 34, 19),
+                new DifferenceTime(1, 2022, 7, 30, 18, 34, 20),
+                new DifferenceTime(1, 2022, 7, 30, 18, 34, 21),
+                new DifferenceTime(2, 2022, 7, 31, 0, 0, 0),
+                new DifferenceTime(3, 2022, 8, 1, 0, 0, 0)
+            ).map(differenceTime -> DynamicTest.dynamicTest(String.format("%s natural time difference between %s and %s", differenceTime.expectDifferenceNaturalTime, startDateTime, differenceTime.endDateTime()),
+                () -> Assertions.assertEquals(differenceTime.expectDifferenceNaturalTime(), DateTimeUtil.between(startDateTime, differenceTime.endDateTime(), ChronoField.EPOCH_DAY))));
+        }
+    }
 
-        betweenDays = DateTimeUtil.between(startDateTime, endDateTime5, ChronoField.EPOCH_DAY);
-        Assertions.assertEquals(1, betweenDays);
+    private record DifferenceTime(int expectDifferenceNaturalTime, int year, int month, int dayOfMonth, int hour,
+                                  int minute, int second) {
+        LocalDateTime endDateTime(){
+            return LocalDateTime.of(year, month, dayOfMonth, hour, minute, second);
+        }
 
-        betweenDays = DateTimeUtil.between(startDateTime, endDateTime6, ChronoField.EPOCH_DAY);
-        Assertions.assertEquals(2, betweenDays);
-
-        betweenDays = DateTimeUtil.between(startDateTime, endDateTime7, ChronoField.EPOCH_DAY);
-        Assertions.assertEquals(3, betweenDays);
     }
 
     @Test
     void testLocalDateToSecond() {
-        OffsetDateTime initDate = OffsetDateTime.of(2023, 2, 5, 0 , 0, 0, 0, ZoneOffset.UTC);
+        OffsetDateTime initDate = OffsetDateTime.of(2023, 2, 5, 0, 0, 0, 0, ZoneOffset.UTC);
         LocalDate date = initDate.toLocalDate();
         Long timestamp = localDateToSecond(date, ZoneOffset.UTC);
         Assertions.assertEquals(timestamp, 1675555200);


### PR DESCRIPTION
Submit a pull request for this project.

<!-- If you have an Issue that related to this Pull Request, you can copy this Issue's description -->

# Why? 

## betweenTest

- Make code cleaner:Only one thing per method
- Testing as documentation

## distinctIgnoreCase

- Use List instead of ArrayList
- Make code cleaner:Consistency at the abstraction level
- Code as Documentation:Using Method Names Instead of Comments

# What?

## betweenTest

```java
@Nested
class BetweenTest {

    private final LocalDateTime startDateTime = LocalDateTime.of(2022, 7, 29, 18, 34, 20);

    @TestFactory
    Stream<DynamicTest> endDateTimeLessStartDateTime() {
        return Stream.of(
            new DifferenceTime(0, 2022, 7, 29, 18, 34, 19),
            new DifferenceTime(0, 2022, 7, 29, 0, 0, 0),
            new DifferenceTime(-1, 2022, 7, 28, 18, 34, 20),
            new DifferenceTime(-2, 2022, 7, 27, 18, 34, 20)
        ).map(differenceTime -> DynamicTest.dynamicTest(String.format("%s natural time difference between %s and %s", differenceTime.expectDifferenceNaturalTime, startDateTime, differenceTime.endDateTime()),
            () -> Assertions.assertEquals(differenceTime.expectDifferenceNaturalTime(), DateTimeUtil.between(startDateTime, differenceTime.endDateTime(), ChronoField.EPOCH_DAY))));
    }

    @Test
    void return0WhenStartDateTimeEqualsEndDateTime() {
        Assertions.assertEquals(0, DateTimeUtil.between(startDateTime, startDateTime, ChronoField.EPOCH_DAY));
    }

    @TestFactory
    Stream<DynamicTest> endDateTimeGreaterStartDateTime() {
        return Stream.of(
            new DifferenceTime(0, 2022, 7, 29, 18, 34, 21),
            new DifferenceTime(1, 2022, 7, 30, 0, 0, 0),
            new DifferenceTime(1, 2022, 7, 30, 18, 34, 19),
            new DifferenceTime(1, 2022, 7, 30, 18, 34, 20),
            new DifferenceTime(1, 2022, 7, 30, 18, 34, 21),
            new DifferenceTime(2, 2022, 7, 31, 0, 0, 0),
            new DifferenceTime(3, 2022, 8, 1, 0, 0, 0)
        ).map(differenceTime -> DynamicTest.dynamicTest(String.format("%s natural time difference between %s and %s", differenceTime.expectDifferenceNaturalTime, startDateTime, differenceTime.endDateTime()),
            () -> Assertions.assertEquals(differenceTime.expectDifferenceNaturalTime(), DateTimeUtil.between(startDateTime, differenceTime.endDateTime(), ChronoField.EPOCH_DAY))));
    }

    private record DifferenceTime(int expectDifferenceNaturalTime, int year, int month, int dayOfMonth, int hour,
                                  int minute, int second) {
        LocalDateTime endDateTime(){
            return LocalDateTime.of(year, month, dayOfMonth, hour, minute, second);
        }

    }
}
```

## distinctIgnoreCase

```java
public static List<String> distinctIgnoreCase(Collection<String> collection) {
    if (CollectionUtils.isEmpty(collection)) {
        return new ArrayList<>();
    }

    Set<String> caseInsensitiveSet = caseInsensitiveSetOf(collection);
    return filterAndCollect(collection, caseInsensitiveSet);
}

private static Set<String> caseInsensitiveSetOf(Collection<String> collection) {
    Set<String> caseInsensitiveSet = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
    caseInsensitiveSet.addAll(collection);
    return caseInsensitiveSet;
}

private static boolean containsSearchStr(String coll, Set<String> sets) {
    return sets.stream().anyMatch(coll::equals);
}

private static List<String> filterAndCollect(Collection<String> collection, Set<String> caseInsensitiveSet) {
    return collection.stream()
        .filter(coll -> containsSearchStr(coll, caseInsensitiveSet))
        .toList();
}
```

# How?

## You can see the documentation after running the test code in idea
![reactor-between-test](https://github.com/apitable/apitable/assets/3048393/f4c7c433-efdb-417a-8dab-bb4c0ed78aae)
