### PR TITLE
fix: useScroller performance

### DIFF
--- a/packages/datasheet/src/pc/components/gantt_view/hooks/use_scroller.ts
+++ b/packages/datasheet/src/pc/components/gantt_view/hooks/use_scroller.ts
@@ -35,11 +35,12 @@ interface IUseScrollerProps {
   pointAreaType?: AreaType;
 }
 
+const emptyRef = { current: null };
 export const useScroller = (props: IUseScrollerProps) => {
   const {
     containerRef,
     gridHorizontalBarRef,
-    ganttHorizontalBarRef = { current: null },
+    ganttHorizontalBarRef = emptyRef,
     verticalBarRef,
     isCellScrolling,
     cellVerticalBarRef,

--- a/packages/datasheet/src/pc/components/gantt_view/hooks/use_scroller.ts
+++ b/packages/datasheet/src/pc/components/gantt_view/hooks/use_scroller.ts
@@ -35,7 +35,7 @@ interface IUseScrollerProps {
   pointAreaType?: AreaType;
 }
 
-const emptyRef = { current: null };
+const emptyRef = Object.freeze({ current: null });
 export const useScroller = (props: IUseScrollerProps) => {
   const {
     containerRef,


### PR DESCRIPTION

Submit a pull request for this project.

<!-- If you have an Issue that related to this Pull Request, you can copy this Issue's description -->

# Why? 
<!-- 
> Related to which issue?
> Why we need this pull request?
> What is the user story for this pull request? 
-->
fix https://github.com/apitable/apitable/issues/1621

# What?
<!-- 
> Can you describe this feature in detail?
> Who can benefit from it? 
-->
ganttHorizontalBarRef默认值每次都会创建一个新的对象，导致依赖此变量的useCallback/useMemo失效

# How?
<!-- 
> Do you have a simple description of how this pull request is implemented?
-->
useScroller不修改ganttHorizontalBarRef.current, 可以放在外面保持默认值引用不变