### PR TITLE
fix: fix @apitable/widget-sdk dependencie

### DIFF
--- a/packages/datasheet/package.json
+++ b/packages/datasheet/package.json
@@ -29,7 +29,7 @@
     "@apitable/i18n-lang": "workspace:*",
     "@apitable/icons": "workspace:*",
     "@apitable/react-flow": "^9.6.12",
-    "@apitable/widget-sdk": "*",
+    "@apitable/widget-sdk": "workspace:*",
     "@floating-ui/react": "0.24.5",
     "@futpib/dagre": "^0.8.5-pre1",
     "@hocuspocus/provider": "^2.5.0",


### PR DESCRIPTION
# 发现几个问题，以及解决的方案如下：

## 一、前置说明：
- 硬件：M1 Max。
- 系统：macOs Sonoma 版本 14.4.1 (23E224)
- 官方开发人员快速入门文档：[链接](https://apitable.getoutline.com/s/751b142b-866f-4174-a5f1-a2975f85ad41/doc/developer-quick-start-zofpBpXg9A)

## 二、启动 `room-serve` 时报错：`Error: The module xxx/canvas.node was compiled against a different Node.js version using`

### 2.1 当我的 NodeJS 版本是 `v16.15.0`，并且在命令行输出 `make run`，然后输入 `2` 启动 `room-serve` 时，出现报错如下：
```bash
Error: The module '/Users/jun/space/opens/apitable/node_modules/.pnpm/canvas@2.9.1/node_modules/canvas/build/Release/canvas.node'
was compiled against a different Node.js version using
NODE_MODULE_VERSION 108. This version of Node.js requires
NODE_MODULE_VERSION 93. Please try re-compiling or re-installing
the module (for instance, using `npm rebuild` or `npm install`).
    at Object.Module._extensions..node (node:internal/modules/cjs/loader:1280:18)
    at Module.load (node:internal/modules/cjs/loader:1074:32)
    at Function.Module._load (node:internal/modules/cjs/loader:909:12)
    at Module.require (node:internal/modules/cjs/loader:1098:19)
    at Module.Hook._require.Module.require (/Users/jun/space/opens/apitable/node_modules/.pnpm/require-in-the-middle@5.2.0/node_modules/require-in-the-middle/index.js:101:39)
    at Module.Hook._require.Module.require (/Users/jun/space/opens/apitable/node_modules/.pnpm/require-in-the-middle@5.2.0/node_modules/require-in-the-middle/index.js:101:39)
    at require (node:internal/modules/cjs/helpers:108:18)
    at Object.<anonymous> (/Users/jun/space/opens/apitable/node_modules/.pnpm/canvas@2.9.1/node_modules/canvas/lib/bindings.js:3:18)
    at Module._compile (node:internal/modules/cjs/loader:1196:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1250:10)
    at Module.load (node:internal/modules/cjs/loader:1074:32)
    at Function.Module._load (node:internal/modules/cjs/loader:909:12)
    at Module.require (node:internal/modules/cjs/loader:1098:19)
    at Module.Hook._require.Module.require (/Users/jun/space/opens/apitable/node_modules/.pnpm/require-in-the-middle@5.2.0/node_modules/require-in-the-middle/index.js:101:39)
    at Module.Hook._require.Module.require (/Users/jun/space/opens/apitable/node_modules/.pnpm/require-in-the-middle@5.2.0/node_modules/require-in-the-middle/index.js:101:39)
    at require (node:internal/modules/cjs/helpers:108:18)
```

### 2.2 解决的方式是把 NodeJS 的版本切换到 `v18.17.0`：
```bash
fnm use v18.17.0
```

## 三、启动 `web-server` 时报错：`Module not found: Can't resolve '@apitable/widget-sdk'`

### 3.1 当我的 NodeJS 版本是 `v16.15.0`，并且在命令行输出 `make run`，然后输入 `3` 启动 `web-serve` 时，出现报错如下：
```bash
error - ./src/pc/common/store_subscribe/dashboard_map.ts:21:0
Module not found: Can't resolve '@apitable/widget-sdk'
  19 | import { difference } from 'lodash';
  20 | import { ResourceType } from '@apitable/core';
> 21 | import { eqSet } from '@apitable/widget-sdk';
  22 | import { resourceService } from 'pc/resource_service';
  23 | import { store } from 'pc/store';
  24 |

Import trace for requested module:
./src/pc/common/store_subscribe/index.ts
./src/pc/common/initializer.ts
./pages/_app.tsx

https://nextjs.org/docs/messages/module-not-found
wait  - compiling...
```

### 3.2 调试后发现 `packages/datasheet/package.json` 对 `@apitable/widget-sdk` 这个依赖的引用有些小问题，需要做如下的修改：
```bash
# 把 `packages/datasheet/package.json` 中的 `"@apitable/widget-sdk": "*"` 改成 `"@apitable/widget-sdk": "workspace:*"`
sed -i "" 's/"@apitable\/widget-sdk": "\*"/"@apitable\/widget-sdk": "workspace:\*"/g' ./packages/datasheet/package.json
```

### 3.3 需要注意的是 `packages/datasheet/package.json` 中对 `@apitable\/widget-sdk` 的依赖修复后需要重新执行如下命令：
```bash
make install
```

## 四、启动 `web-serve` 时报错：`Error: The module xxx/canvas.node was compiled against a different Node.js version using`


### 4.1 当我修复了 `Module not found: Can't resolve '@apitable/widget-sdk'` 时，启动命令行输出 `make run`，然后输入 `3` 启动 `web-serve`，报了如下的错误：
```bash
<w> [webpack.cache.PackFileCacheStrategy] Caching failed for pack: Error: ENOENT: no such file or directory, rename '/Users/jun/space/opens/apitable/packages/datasheet/web_build/cache/webpack/client-development-fallback/0.pack_' -> '/Users/jun/space/opens/apitable/packages/datasheet/web_build/cache/webpack/client-development-fallback/0.pack'
Error: The module '/Users/jun/space/opens/apitable/node_modules/.pnpm/canvas@2.9.1/node_modules/canvas/build/Release/canvas.node'
was compiled against a different Node.js version using
NODE_MODULE_VERSION 108. This version of Node.js requires
NODE_MODULE_VERSION 93. Please try re-compiling or re-installing
the module (for instance, using `npm rebuild` or `npm install`).
    at Object.Module._extensions..node (node:internal/modules/cjs/loader:1189:18)
    at Module.load (node:internal/modules/cjs/loader:981:32)
    at Function.Module._load (node:internal/modules/cjs/loader:822:12)
    at Module.require (node:internal/modules/cjs/loader:1005:19)
    at require (node:internal/modules/cjs/helpers:102:18)
    at Object.<anonymous> (/Users/jun/space/opens/apitable/node_modules/.pnpm/canvas@2.9.1/node_modules/canvas/lib/bindings.js:3:18)
    at Module._compile (node:internal/modules/cjs/loader:1105:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1159:10)
    at Module.load (node:internal/modules/cjs/loader:981:32)
    at Function.Module._load (node:internal/modules/cjs/loader:822:12)
    at Module.require (node:internal/modules/cjs/loader:1005:19)
    at require (node:internal/modules/cjs/helpers:102:18)
    at Object.<anonymous> (/Users/jun/space/opens/apitable/node_modules/.pnpm/canvas@2.9.1/node_modules/canvas/lib/canvas.js:9:18)
    at Module._compile (node:internal/modules/cjs/loader:1105:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1159:10)
    at Module.load (node:internal/modules/cjs/loader:981:32)
    at Function.Module._load (node:internal/modules/cjs/loader:822:12)
    at Module.require (node:internal/modules/cjs/loader:1005:19)
    at require (node:internal/modules/cjs/helpers:102:18)
    at Object.<anonymous> (/Users/jun/space/opens/apitable/node_modules/.pnpm/canvas@2.9.1/node_modules/canvas/index.js:1:16)
    at Module._compile (node:internal/modules/cjs/loader:1105:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1159:10)
    at Module.load (node:internal/modules/cjs/loader:981:32)
    at Function.Module._load (node:internal/modules/cjs/loader:822:12)
    at Module.require (node:internal/modules/cjs/loader:1005:19)
    at require (node:internal/modules/cjs/helpers:102:18)
    at Object.<anonymous> (/Users/jun/space/opens/apitable/node_modules/.pnpm/konva@8.4.3/node_modules/konva/cmj/index-node.js:4:16)
    at Module._compile (node:internal/modules/cjs/loader:1105:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1159:10)
    at Module.load (node:internal/modules/cjs/loader:981:32)
    at Function.Module._load (node:internal/modules/cjs/loader:822:12)
    at Module.require (node:internal/modules/cjs/loader:1005:19)
    at require (node:internal/modules/cjs/helpers:102:18)
    at Object.konva (/Users/jun/space/opens/apitable/packages/datasheet/web_build/server/pages/_app.js:61290:18)
    at __webpack_require__ (/Users/jun/space/opens/apitable/packages/datasheet/web_build/server/webpack-runtime.js:33:43)
    at eval (webpack-internal:///./src/pc/components/gantt_view/gantt_stage/gantt_stage.tsx:10:63)
    at Function.__webpack_require__.a (/Users/jun/space/opens/apitable/packages/datasheet/web_build/server/webpack-runtime.js:97:13)
    at eval (webpack-internal:///./src/pc/components/gantt_view/gantt_stage/gantt_stage.tsx:1:21)
    at Module../src/pc/components/gantt_view/gantt_stage/gantt_stage.tsx (/Users/jun/space/opens/apitable/packages/datasheet/web_build/server/pages/_app.js:19618:1)
    at __webpack_require__ (/Users/jun/space/opens/apitable/packages/datasheet/web_build/server/webpack-runtime.js:33:43)
    at eval (webpack-internal:///./src/pc/components/gantt_view/gantt_view.tsx:31:107)
    at Function.__webpack_require__.a (/Users/jun/space/opens/apitable/packages/datasheet/web_build/server/webpack-runtime.js:97:13)
    at eval (webpack-internal:///./src/pc/components/gantt_view/gantt_view.tsx:1:21)
    at Module../src/pc/components/gantt_view/gantt_view.tsx (/Users/jun/space/opens/apitable/packages/datasheet/web_build/server/pages/_app.js:19629:1)
    at __webpack_require__ (/Users/jun/space/opens/apitable/packages/datasheet/web_build/server/webpack-runtime.js:33:43)
    at eval (webpack-internal:///./src/pc/components/gantt_view/index.ts:3:69)
    at Function.__webpack_require__.a (/Users/jun/space/opens/apitable/packages/datasheet/web_build/server/webpack-runtime.js:97:13)
    at eval (webpack-internal:///./src/pc/components/gantt_view/index.ts:1:21)
    at Module../src/pc/components/gantt_view/index.ts (/Users/jun/space/opens/apitable/packages/datasheet/web_build/server/pages/_app.js:19838:1)
    at __webpack_require__ (/Users/jun/space/opens/apitable/packages/datasheet/web_build/server/webpack-runtime.js:33:43) {
  code: 'ERR_DLOPEN_FAILED'
}
```

### 4.2 解决的方式是把 NodeJS 的版本切换到 `v18.17.0`：
```bash
fnm use v18.17.0
```

# 五、基于我本人的实验条件和系统版本，对上面的启动过程做一个简单的总结：
- 在执行 `make install` 时，按照官方的文档使用 NodeJS 的 `v16.15.0`。
- 在启动 `backend-server` 时，NodeJS 的 `v16.15.0` 并没有报错，所以 NodeJS 的 `v16.15.0` 在这个阶段是没有问题的。
- 在启动 `room-serve` 和 `web-serve` 时，NodeJS 的需要切换成 `v18.17.0` (其他版本的没有测试过)。
- `packages/datasheet/package.json` 中的 `"@apitable/widget-sdk": "*"` 需要改成 `"@apitable/widget-sdk": "workspace:*"`。
- `databus-server` 阶段的启动似乎仅仅是和 `docker` 相关，和 NodeJS 无关。