### PR TITLE
build: ignore hidden files

### DIFF
--- a/backend-server/settings.gradle
+++ b/backend-server/settings.gradle
@@ -12,6 +12,6 @@ include 'shared:core'
 
 include 'application'
 
-file("${rootDir}/shared/starters").eachDirMatch(~/.*/) {
+file("${rootDir}/shared/starters").eachDirMatch(~/^(?!\.).*/) {
     include "shared:starters:${it.name}"
 }


### PR DESCRIPTION

Submit a pull request for this project.

<!-- If you have an Issue that related to this Pull Request, you can copy this Issue's description -->

# Why? 
If using jdtls, some jdtls files (.settings, .project) will be generated in the shared/starters directory. These files should be ignored.

![image](https://github.com/apitable/apitable/assets/24953151/d8733830-859b-4ada-a305-64c458741337)

![image](https://github.com/apitable/apitable/assets/24953151/5123d7b4-b362-428a-aeec-ce7fdb3a02b9)


# What?
<!-- 
> Can you describe this feature in detail?
> Who can benefit from it? 
-->


# How?
<!-- 
> Do you have a simple description of how this pull request is implemented?
-->
