### PR TITLE
fix: getBrowserLanguage() bug, search in languageMap's keyArray always fails

### DIFF
--- a/packages/core/src/exports/i18n/index.ts
+++ b/packages/core/src/exports/i18n/index.ts
@@ -61,7 +61,6 @@ const getBrowserLanguage = (): string | undefined => {
     userLanguage = 'zh-HK';
   }
   if (!languageMap[userLanguage]) {
-    userLanguage = undefined;
     const langArr = Object.keys(languageMap);
     if (langArr) {
       for (let i = 0; i < langArr.length; i++) {


### PR DESCRIPTION
A bug in the getBrowserLanguage() function. 

As shown in the follwing screen shot, because of line 64, langArr[i].indexOf() in line 69 will always be langArr[i].indexOf(undefined) which leads to search failure.

![图片](https://github.com/user-attachments/assets/f95540da-b91e-4f0d-ac6c-3e27da8b0f24)
