### PR TITLE
fix all in one script

### DIFF
--- a/packaging/all-in-one/all-in-one/script/init-appdata.sh
+++ b/packaging/all-in-one/all-in-one/script/init-appdata.sh
@@ -27,8 +27,8 @@ liquibase \
     --database-changelog-lock-table-name="${DATABASE_TABLE_PREFIX:=apitable_}db_changelog_lock" \
     --url="jdbc:mysql://${MYSQL_HOST}:${MYSQL_PORT}/${MYSQL_DATABASE}?characterEncoding=utf8&autoReconnect=true&useSSL=true" \
     update \
-    -Dtable.prefix="${DATABASE_TABLE_PREFIX:=apitable_} \
-    -DDB_ENGINE=${DB_ENGINE:=mysql}"
+    -Dtable.prefix="${DATABASE_TABLE_PREFIX:=apitable_}" \
+    -DDB_ENGINE="${DB_ENGINE:=mysql}"
 
 cd /app/init-appdata
 


### PR DESCRIPTION
Caused by: liquibase.exception.DatabaseException: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near '-DDB_ENGINE=mysqlclient_release_version change  `describe`  `description`  varch' at line 1 [Failed SQL: (1064) ALTER TABLE apitable_     -DDB_ENGINE=mysqlclient_release_version change  `describe`  `description`  varchar(255) not null comment 'Version Description']
	at liquibase.executor.jvm.JdbcExecutor$ExecuteStatementCallback.doInStatement(JdbcExecutor.java:445)
	at liquibase.executor.jvm.JdbcExecutor.execute(JdbcExecutor.java:77)
	at liquibase.executor.jvm.JdbcExecutor.execute(JdbcExecutor.java:160)
	at liquibase.database.AbstractJdbcDatabase.execute(AbstractJdbcDatabase.java:1287)
	at liquibase.database.AbstractJdbcDatabase.executeStatements(AbstractJdbcDatabase.java:1269)
	at liquibase.changelog.ChangeSet.execute(ChangeSet.java:718)
	... 51 more



Submit a pull request for this project.

<!-- If you have an Issue that related to this Pull Request, you can copy this Issue's description -->

# Why? 
<!-- 
> Related to which issue?
> Why we need this pull request?
> What is the user story for this pull request? 
-->


# What?
<!-- 
> Can you describe this feature in detail?
> Who can benefit from it? 
-->


# How?
<!-- 
> Do you have a simple description of how this pull request is implemented?
-->
