### PR TITLE
Add RepoCloud one-click deploy badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@
     <a target="_blank" href="https://app.trydome.io/signup?package=apitable">
         <img src="https://trydome.io/dome-badge.svg" />
     </a>
+    <!-- Deploy to RepoCloud-->
+    <a target="_blank" href="https://repocloud.io/details/APITable/">
+        <img src="https://d16t0pc4846x52.cloudfront.net/deploylobe.svg" alt="Deploy on RepoCloud" height="20" />
+    </a>
 </p>
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@
     </a>
     <!-- Deploy to RepoCloud-->
     <a target="_blank" href="https://repocloud.io/details/APITable/">
-        <img src="https://d16t0pc4846x52.cloudfront.net/deploylobe.svg" alt="Deploy on RepoCloud" height="20" />
+        <img src="https://dnk92k33or340.cloudfront.net/deploy-20px.png" alt="Deploy on RepoCloud" height="20" />
     </a>
 </p>
 


### PR DESCRIPTION
Added a RepoCloud deploy badge in the header badge section, alongside the existing DigitalOcean and Dome deploy badges.

The badge links to https://repocloud.io/details/APITable/ where users can deploy APITable with one click.