### PR TITLE
fix: handle CRLF line breaks in grid text

### DIFF
--- a/packages/datasheet/src/pc/components/konva_grid/utils/__tests__/drawer.test.ts
+++ b/packages/datasheet/src/pc/components/konva_grid/utils/__tests__/drawer.test.ts
@@ -1,0 +1,73 @@
+/**
+ * APITable <https://github.com/apitable/apitable>
+ * Copyright (C) 2022 APITable Ltd. <https://apitable.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+jest.mock('@apitable/components', () => ({ colors: { firstLevelText: '#000' }, ThemeName: {} }), { virtual: true });
+jest.mock('@apitable/core', () => ({ SegmentType: { Url: 'Url' } }), { virtual: true });
+jest.mock(
+  '@apitable/icons',
+  () => ({
+    UserGroupOutlined: { toString: () => '' },
+    WebOutlined: { toString: () => '' },
+  }),
+  { virtual: true },
+);
+jest.mock('@apitable/widget-sdk', () => ({ assertSignatureManager: jest.fn() }), { virtual: true });
+jest.mock(
+  'pc/components/common',
+  () => ({
+    AvatarSize: {},
+    AvatarType: {},
+    getAvatarRandomColor: jest.fn(),
+    getFirstWordFromString: jest.fn(),
+  }),
+  { virtual: true },
+);
+jest.mock('pc/components/konva_components', () => ({ autoSizerCanvas: { context: {} } }), { virtual: true });
+jest.mock('pc/utils/color_utils', () => ({ createAvatarRainbowColorsArr: jest.fn(() => []) }), { virtual: true });
+jest.mock('pc/utils/env', () => ({ getEnvVariables: jest.fn(() => ({})) }), { virtual: true });
+jest.mock('../get_text_width', () => ({
+  getTextWidth: jest.fn((_ctx: CanvasRenderingContext2D, text: string) => text.length),
+  textDataCache: new Map(),
+}));
+jest.mock('../image_cache', () => ({ imageCache: new Map() }));
+
+import { KonvaDrawer } from '../drawer';
+
+describe('KonvaDrawer.wrapText', () => {
+  it.each(['\n', '\r', '\r\n'])('treats %j as a single line break', (lineBreak) => {
+    const drawer = new KonvaDrawer();
+    drawer.ctx = {
+      measureText: (text: string) => ({ width: text.length }),
+    } as CanvasRenderingContext2D;
+
+    const result = drawer.wrapText({
+      x: 0,
+      y: 0,
+      text: `A${lineBreak}B`,
+      maxWidth: 100,
+      lineHeight: 24,
+      maxRow: Infinity,
+      fieldType: 0,
+    });
+
+    expect(result.data.map(({ text, offsetY }) => ({ text, offsetY }))).toEqual([
+      { text: 'A', offsetY: 0 },
+      { text: 'B', offsetY: 24 },
+    ]);
+  });
+});

--- a/packages/datasheet/src/pc/components/konva_grid/utils/drawer.ts
+++ b/packages/datasheet/src/pc/components/konva_grid/utils/drawer.ts
@@ -296,7 +296,7 @@ export class KonvaDrawer {
 
     for (let n = 0; n < textLength; n++) {
       const curText = arrText[n];
-      const isLineBreak = ['\n', '\r'].includes(curText);
+      const isLineBreak = ['\n', '\r', '\r\n'].includes(curText);
       const singleText = isLineBreak ? '' : curText;
       const composeText = showText + singleText;
       const isLimitRow = maxRow ? rowCount >= maxRow - 1 : false;


### PR DESCRIPTION
# Why?

Fixes #1597.

`grapheme-splitter` returns CRLF (`\r\n`) as one grapheme, while the grid text renderer only recognized standalone LF and CR characters. As a result, imported CRLF text stayed on one canvas line and could overlap when the cell was active.

# What?

- Treat CRLF as a single line break in `KonvaDrawer.wrapText`.
- Add focused regression coverage for LF, CR, and CRLF input.

# How?

Extend the existing line-break predicate without normalizing the source string, so the renderer keeps the original text and segment indexes intact.

# Verification

- Focused Jest regression: 3 tests passed.
- `pnpm build:dst:pre`
- `pnpm --filter @apitable/datasheet check`
- Targeted ESLint and Prettier checks.

The existing Datasheet `test` script invokes `next test` and fails before Jest starts on the base branch, so the focused regression was run directly with Jest and the repository's SWC transformer.
